### PR TITLE
Guard invalid continuous legend start and end values

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,4 @@ src/mixins/coordinate-grid-raster-mixin.js
 src/mixins/raster-layer-point-mixin.unit.spec.js
 src/utils/utils-lasso.unit.spec.js
 test/setup-unit-tests.js
-mapd-charting/src/polyfills/inner-svg.js
+src/polyfills/inner-svg.js

--- a/src/chart-addons/dc-legend-cont.js
+++ b/src/chart-addons/dc-legend-cont.js
@@ -226,7 +226,7 @@ export default function legendCont() {
     const startVal = isFinite(inputBox1) ? inputBox1 : _parent.colorDomain()[0]
     const endVal = isFinite(inputBox2) ? inputBox2 : _parent.colorDomain()[1]
 
-    if (!isNaN(startVal) && !isNaN(endVal)) {
+    if (!isNaN(startVal) && !isNaN(endVal) && startVal < endVal) {
       _isLocked = true
       _parent
         .colorDomain([startVal, endVal])

--- a/src/polyfills/inner-svg.js
+++ b/src/polyfills/inner-svg.js
@@ -1,4 +1,4 @@
-(function() {
+;(function() {
   /* istanbul ignore next */
   if (window.SVGElement) {
     var serializeXML = function(node, output) {

--- a/src/polyfills/inner-svg.js
+++ b/src/polyfills/inner-svg.js
@@ -1,4 +1,4 @@
-;(function() {
+(function() {
   /* istanbul ignore next */
   if (window.SVGElement) {
     var serializeXML = function(node, output) {


### PR DESCRIPTION
Fixes behavioral issue in https://github.com/mapd/mapd-immerse/issues/3942, by short-circuiting a change to the start value and end value inputs on a continuous legend if the start value is greater than the end value.