### PR TITLE
bump version to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapd/mapdc",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapd/mapdc",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "copyright": "2017",
   "description": "A multi-dimensional charting library built to work natively with crossfilter and rendered using d3.js.",


### PR DESCRIPTION
It would be useful to publish mapd-charting to npmjs for our workshop. @uyanga-gb just compiled it, so it's just a matter of merging this one to master and I will run `npm publish`

FYI, I opened a PR just to see the difference between when I compile it and what was last compiled. It's not required for publishing it, but it may be useful to just have a look to see if there are some differences aside from the compiling artifacts that got missed. https://github.com/mapd/mapd-charting/pull/210