### PR TITLE
change API Docs URL to correct URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Our [Tweetmap Demo](https://www.mapd.com/demos/tweetmap/) was made only using Ma
 
 # Documentation
 
-Visit our [API Docs](http://mapd.github.io/mapd-charting/docs/) for additional information on MapD Charting
+Visit our [API Docs](https://omnisci.github.io/mapd-charting/docs/) for additional information on MapD Charting
 
 # Testing
 


### PR DESCRIPTION
Hi, very simple PR for fixing a URL that's been an annoyance for me when looking for api docs :P
Dunno if you need me to go through the checklist or not.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
