### PR TITLE
[FE-15044] first draft adding align buttons to table chart

### DIFF
--- a/dist/charting.css
+++ b/dist/charting.css
@@ -751,6 +751,12 @@ body {
         color: #22A7F0; }
       .dc-chart .md-table-wrapper td.disabled {
         pointer-events: none; }
+      .dc-chart .md-table-wrapper td.cell-align-left {
+        text-align: left; }
+      .dc-chart .md-table-wrapper td.cell-align-right {
+        text-align: right; }
+      .dc-chart .md-table-wrapper td.cell-align-center {
+        text-align: center; }
     .dc-chart .md-table-wrapper th {
       border-bottom: 1px solid #e2e2e2;
       color: #868686;
@@ -1138,12 +1144,6 @@ body {
         text-align: left; }
     .chart-popup .popup-table td {
       cursor: pointer; }
-    .chart-popup .popup-table td.cell-align-left {
-      text-align: left; }
-    .chart-popup .popup-table td.cell-align-right {
-      text-align: right; }
-    .chart-popup .popup-table td.cell-align-center {
-      text-align: center; }
     .chart-popup .popup-table th {
       position: relative; }
       .chart-popup .popup-table th .ellipse-text {

--- a/dist/charting.css
+++ b/dist/charting.css
@@ -1138,6 +1138,12 @@ body {
         text-align: left; }
     .chart-popup .popup-table td {
       cursor: pointer; }
+    .chart-popup .popup-table td.cell-align-left {
+      text-align: left; }
+    .chart-popup .popup-table td.cell-align-right {
+      text-align: right; }
+    .chart-popup .popup-table td.cell-align-center {
+      text-align: center; }
     .chart-popup .popup-table th {
       position: relative; }
       .chart-popup .popup-table th .ellipse-text {

--- a/dist/charting.css
+++ b/dist/charting.css
@@ -792,11 +792,11 @@ body {
     position: relative;
     white-space: nowrap; }
     .dc-chart .table-header-item .left-align-btn, .dc-chart .table-header-item .center-align-btn, .dc-chart .table-header-item .right-align-btn {
-      width: 48px;
-      height: 48px;
+      width: 20px;
+      height: 20px;
       position: absolute;
       right: 0;
-      top: 3px;
+      top: 0;
       padding: 4px;
       cursor: pointer;
       display: none; }

--- a/dist/charting.css
+++ b/dist/charting.css
@@ -794,7 +794,7 @@ body {
       padding: 4px;
       cursor: pointer;
       display: none; }
-      .dc-chart .table-header-item .left-align-btn .svg-icon.active, .dc-chart .table-header-item .center-align-btn .svg-icon.active, .dc-chart .table-header-item .right-align-btn .svg-icon.active {
+      .dc-chart .table-header-item .left-align-btn.active .svg-icon, .dc-chart .table-header-item .center-align-btn.active .svg-icon, .dc-chart .table-header-item .right-align-btn.active .svg-icon {
         fill: #22A7F0; }
       .dc-chart .table-header-item .left-align-btn:hover .svg-icon, .dc-chart .table-header-item .center-align-btn:hover .svg-icon, .dc-chart .table-header-item .right-align-btn:hover .svg-icon {
         fill: #22A7F0; }

--- a/dist/charting.css
+++ b/dist/charting.css
@@ -786,17 +786,21 @@ body {
     position: relative;
     white-space: nowrap; }
     .dc-chart .table-header-item .left-align-btn, .dc-chart .table-header-item .center-align-btn, .dc-chart .table-header-item .right-align-btn {
-      width: 24px;
-      height: 24px;
+      width: 48px;
+      height: 48px;
       position: absolute;
       right: 0;
-      top: 0;
+      top: 3px;
       padding: 4px;
       cursor: pointer;
       display: none; }
-    .dc-chart .table-header-item.isFiltered .unfilter-btn {
-      display: block; }
+      .dc-chart .table-header-item .left-align-btn .svg-icon.active, .dc-chart .table-header-item .center-align-btn .svg-icon.active, .dc-chart .table-header-item .right-align-btn .svg-icon.active {
+        fill: #22A7F0; }
+      .dc-chart .table-header-item .left-align-btn:hover .svg-icon, .dc-chart .table-header-item .center-align-btn:hover .svg-icon, .dc-chart .table-header-item .right-align-btn:hover .svg-icon {
+        fill: #22A7F0; }
     .dc-chart .table-header-item:hover .left-align-btn, .dc-chart .table-header-item:hover .center-align-btn, .dc-chart .table-header-item:hover .right-align-btn {
+      display: block; }
+    .dc-chart .table-header-item.isFiltered .unfilter-btn {
       display: block; }
     .dc-chart .table-header-item .unfilter-btn {
       width: 24px;

--- a/dist/charting.css
+++ b/dist/charting.css
@@ -792,12 +792,12 @@ body {
     position: relative;
     white-space: nowrap; }
     .dc-chart .table-header-item .left-align-btn, .dc-chart .table-header-item .center-align-btn, .dc-chart .table-header-item .right-align-btn {
-      width: 20px;
-      height: 20px;
+      width: 18px;
+      height: 24px;
       position: absolute;
       right: 0;
-      top: 0;
-      padding: 4px;
+      top: 1px;
+      padding: 4px 0px;
       cursor: pointer;
       display: none; }
       .dc-chart .table-header-item .left-align-btn.active .svg-icon, .dc-chart .table-header-item .center-align-btn.active .svg-icon, .dc-chart .table-header-item .right-align-btn.active .svg-icon {

--- a/dist/charting.css
+++ b/dist/charting.css
@@ -785,7 +785,18 @@ body {
   .dc-chart .table-header-item {
     position: relative;
     white-space: nowrap; }
+    .dc-chart .table-header-item .left-align-btn, .dc-chart .table-header-item .center-align-btn, .dc-chart .table-header-item .right-align-btn {
+      width: 24px;
+      height: 24px;
+      position: absolute;
+      right: 0;
+      top: 0;
+      padding: 4px;
+      cursor: pointer;
+      display: none; }
     .dc-chart .table-header-item.isFiltered .unfilter-btn {
+      display: block; }
+    .dc-chart .table-header-item:hover .left-align-btn, .dc-chart .table-header-item:hover .center-align-btn, .dc-chart .table-header-item:hover .right-align-btn {
       display: block; }
     .dc-chart .table-header-item .unfilter-btn {
       width: 24px;

--- a/dist/charting.js
+++ b/dist/charting.js
@@ -86319,14 +86319,14 @@ function heavyaiTable(parent, chartGroup) {
           _chart._invokeAlignListener(_columnAlignments);
           _chart.redrawAsync();
         }
-      }).style("left", headerItem.node().getBoundingClientRect().width - GROUP_DATA_WIDTH * 3 + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-left", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-caret-left");
+      }).style("left", headerItem.node().getBoundingClientRect().width - GROUP_DATA_WIDTH * 2 + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-left", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-caret-left");
 
       // center align button
       headerItem.append("div").attr("class", "center-align-btn").classed("active", function () {
         return _chart.isColCenterAligned(i);
       }).on("click", function () {
         if (!_chart.isColCenterAligned(i)) {
-          _columnAlignments[i] = "left";
+          _columnAlignments[i] = "center";
           _chart._invokeAlignListener(_columnAlignments);
           _chart.redrawAsync();
         }

--- a/dist/charting.js
+++ b/dist/charting.js
@@ -86319,7 +86319,7 @@ function heavyaiTable(parent, chartGroup) {
           _chart._invokeAlignListener(_columnAlignments);
           _chart.redrawAsync();
         }
-      }).style("left", headerItem.node().getBoundingClientRect().width - 60 + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-left", true).attr("viewBox", "0 0 16 16").append("use").attr("xlink:href", "#icon-caret-left");
+      }).style("left", headerItem.node().getBoundingClientRect().width - 54 + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-left", true).attr("viewBox", "0 0 16 16").append("use").attr("xlink:href", "#icon-caret-left");
 
       // center align button
       headerItem.append("div").attr("class", "center-align-btn").classed("active", function () {
@@ -86330,7 +86330,7 @@ function heavyaiTable(parent, chartGroup) {
           _chart._invokeAlignListener(_columnAlignments);
           _chart.redrawAsync();
         }
-      }).style("left", headerItem.node().getBoundingClientRect().width - 40 + "px").append("svg").attr("class", "svg-icon").classed("icon-align-center", true).attr("viewBox", "0 0 16 16").append("use").attr("xlink:href", "#icon-align-center");
+      }).style("left", headerItem.node().getBoundingClientRect().width - 36 + "px").append("svg").attr("class", "svg-icon").classed("icon-align-center", true).attr("viewBox", "0 0 16 16").append("use").attr("xlink:href", "#icon-align-center");
 
       // right align button
       headerItem.append("div").attr("class", "right-align-btn").classed("active", function () {
@@ -86341,7 +86341,7 @@ function heavyaiTable(parent, chartGroup) {
           _chart._invokeAlignListener(_columnAlignments);
           _chart.redrawAsync();
         }
-      }).style("left", headerItem.node().getBoundingClientRect().width - 20 + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-right", true).attr("viewBox", "0 0 16 16").append("use").attr("xlink:href", "#icon-caret-right");
+      }).style("left", headerItem.node().getBoundingClientRect().width - 18 + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-right", true).attr("viewBox", "0 0 16 16").append("use").attr("xlink:href", "#icon-caret-right");
 
       headerItem.append("div").attr("class", "unfilter-btn").attr("data-expr", d.expression).on("click", function () {
         clearColFilter(_d2.default.select(this).attr("data-expr"));

--- a/dist/charting.js
+++ b/dist/charting.js
@@ -86319,7 +86319,7 @@ function heavyaiTable(parent, chartGroup) {
           _chart._invokeAlignListener(_columnAlignments);
           _chart.redrawAsync();
         }
-      }).style("left", headerItem.node().getBoundingClientRect().width - 48 * 3 + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-left", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-caret-left");
+      }).style("left", headerItem.node().getBoundingClientRect().width - GROUP_DATA_WIDTH * 3 + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-left", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-caret-left");
 
       // center align button
       headerItem.append("div").attr("class", "center-align-btn").classed("active", function () {
@@ -86330,7 +86330,7 @@ function heavyaiTable(parent, chartGroup) {
           _chart._invokeAlignListener(_columnAlignments);
           _chart.redrawAsync();
         }
-      }).style("left", headerItem.node().getBoundingClientRect().width - 48 * 2 + "px").append("svg").attr("class", "svg-icon").classed("icon-align-center", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-align-center");
+      }).style("left", headerItem.node().getBoundingClientRect().width - GROUP_DATA_WIDTH * 1.5 + "px").append("svg").attr("class", "svg-icon").classed("icon-align-center", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-align-center");
 
       // right align button
       headerItem.append("div").attr("class", "right-align-btn").classed("active", function () {
@@ -86341,7 +86341,7 @@ function heavyaiTable(parent, chartGroup) {
           _chart._invokeAlignListener(_columnAlignments);
           _chart.redrawAsync();
         }
-      }).style("left", headerItem.node().getBoundingClientRect().width - 48 + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-right", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-caret-right");
+      }).style("left", headerItem.node().getBoundingClientRect().width - GROUP_DATA_WIDTH + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-right", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-caret-right");
 
       headerItem.append("div").attr("class", "unfilter-btn").attr("data-expr", d.expression).on("click", function () {
         clearColFilter(_d2.default.select(this).attr("data-expr"));

--- a/dist/charting.js
+++ b/dist/charting.js
@@ -86319,7 +86319,7 @@ function heavyaiTable(parent, chartGroup) {
           _chart._invokeAlignListener(_columnAlignments);
           _chart.redrawAsync();
         }
-      }).style("left", headerItem.node().getBoundingClientRect().width - GROUP_DATA_WIDTH * 2 + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-left", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-caret-left");
+      }).style("left", headerItem.node().getBoundingClientRect().width - 60 + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-left", true).attr("viewBox", "0 0 16 16").append("use").attr("xlink:href", "#icon-caret-left");
 
       // center align button
       headerItem.append("div").attr("class", "center-align-btn").classed("active", function () {
@@ -86330,7 +86330,7 @@ function heavyaiTable(parent, chartGroup) {
           _chart._invokeAlignListener(_columnAlignments);
           _chart.redrawAsync();
         }
-      }).style("left", headerItem.node().getBoundingClientRect().width - GROUP_DATA_WIDTH * 1.5 + "px").append("svg").attr("class", "svg-icon").classed("icon-align-center", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-align-center");
+      }).style("left", headerItem.node().getBoundingClientRect().width - 40 + "px").append("svg").attr("class", "svg-icon").classed("icon-align-center", true).attr("viewBox", "0 0 16 16").append("use").attr("xlink:href", "#icon-align-center");
 
       // right align button
       headerItem.append("div").attr("class", "right-align-btn").classed("active", function () {
@@ -86341,7 +86341,7 @@ function heavyaiTable(parent, chartGroup) {
           _chart._invokeAlignListener(_columnAlignments);
           _chart.redrawAsync();
         }
-      }).style("left", headerItem.node().getBoundingClientRect().width - GROUP_DATA_WIDTH + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-right", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-caret-right");
+      }).style("left", headerItem.node().getBoundingClientRect().width - 20 + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-right", true).attr("viewBox", "0 0 16 16").append("use").attr("xlink:href", "#icon-caret-right");
 
       headerItem.append("div").attr("class", "unfilter-btn").attr("data-expr", d.expression).on("click", function () {
         clearColFilter(_d2.default.select(this).attr("data-expr"));

--- a/dist/charting.js
+++ b/dist/charting.js
@@ -86319,7 +86319,7 @@ function heavyaiTable(parent, chartGroup) {
           _chart._invokeAlignListener(_columnAlignments);
           _chart.redrawAsync();
         }
-      }).append("svg").attr("class", "svg-icon").classed("icon-caret-left", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-caret-left");
+      }).style("left", headerItem.node().getBoundingClientRect().width - 48 * 3 + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-left", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-caret-left");
 
       // center align button
       headerItem.append("div").attr("class", "center-align-btn").classed("active", function () {
@@ -86330,7 +86330,7 @@ function heavyaiTable(parent, chartGroup) {
           _chart._invokeAlignListener(_columnAlignments);
           _chart.redrawAsync();
         }
-      }).append("svg").attr("class", "svg-icon").classed("icon-align-center", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-align-center");
+      }).style("left", headerItem.node().getBoundingClientRect().width - 48 * 2 + "px").append("svg").attr("class", "svg-icon").classed("icon-align-center", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-align-center");
 
       // right align button
       headerItem.append("div").attr("class", "right-align-btn").classed("active", function () {
@@ -86341,7 +86341,7 @@ function heavyaiTable(parent, chartGroup) {
           _chart._invokeAlignListener(_columnAlignments);
           _chart.redrawAsync();
         }
-      }).append("svg").attr("class", "svg-icon").classed("icon-caret-right", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-caret-right");
+      }).style("left", headerItem.node().getBoundingClientRect().width - 48 + "px").append("svg").attr("class", "svg-icon").classed("icon-caret-right", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-caret-right");
 
       headerItem.append("div").attr("class", "unfilter-btn").attr("data-expr", d.expression).on("click", function () {
         clearColFilter(_d2.default.select(this).attr("data-expr"));

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -605,6 +605,18 @@ body {
             &.disabled {
                 pointer-events: none;
             }
+
+            &.cell-align-left {
+                text-align: left;
+            }
+
+            &.cell-align-right {
+                text-align: right;
+            }
+
+            &.cell-align-center {
+                text-align: center;
+            }
         }
 
         th {
@@ -1247,18 +1259,6 @@ body {
 
         td {
             cursor: pointer;
-        }
-
-        td.cell-align-left {
-            text-align: left;
-        }
-
-        td.cell-align-right {
-            text-align: right;
-        }
-
-        td.cell-align-center {
-            text-align: center;
         }
 
         th {

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -674,8 +674,10 @@ body {
             cursor: pointer;
             display: none;
 
-            .svg-icon.active {
-                fill: $blue-main;
+            &.active {
+                .svg-icon {
+                    fill: $blue-main;
+                }
             }
 
             &:hover {

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -1249,6 +1249,18 @@ body {
             cursor: pointer;
         }
 
+        td.cell-align-left {
+            text-align: left;
+        }
+
+        td.cell-align-right {
+            text-align: right;
+        }
+
+        td.cell-align-center {
+            text-align: center;
+        }
+
         th {
             position: relative;
 

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -677,12 +677,12 @@ body {
         white-space: nowrap;
 
         .left-align-btn, .center-align-btn, .right-align-btn {
-            width: 20px;
-            height: 20px;
+            width: 18px;
+            height: 24px;
             position: absolute;
             right: 0;
-            top: 0;
-            padding: 4px;
+            top: 1px;
+            padding: 4px 0px;
             cursor: pointer;
             display: none;
 

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -664,8 +664,25 @@ body {
         position: relative;
         white-space: nowrap;
 
+        .left-align-btn, .center-align-btn, .right-align-btn {
+            width: 24px;
+            height: 24px;
+            position: absolute;
+            right: 0;
+            top: 0;
+            padding: 4px;
+            cursor: pointer;
+            display: none;
+        }
+
         &.isFiltered {
             .unfilter-btn {
+                display: block;
+            }
+        }
+
+        &:hover {
+            .left-align-btn, .center-align-btn, .right-align-btn {
                 display: block;
             }
         }

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -665,24 +665,34 @@ body {
         white-space: nowrap;
 
         .left-align-btn, .center-align-btn, .right-align-btn {
-            width: 24px;
-            height: 24px;
+            width: 48px;
+            height: 48px;
             position: absolute;
             right: 0;
-            top: 0;
+            top: 3px;
             padding: 4px;
             cursor: pointer;
             display: none;
-        }
 
-        &.isFiltered {
-            .unfilter-btn {
-                display: block;
+            .svg-icon.active {
+                fill: $blue-main;
+            }
+
+            &:hover {
+                .svg-icon {
+                    fill: $blue-main;
+                }
             }
         }
 
         &:hover {
             .left-align-btn, .center-align-btn, .right-align-btn {
+                display: block;
+            }
+        }
+
+        &.isFiltered {
+            .unfilter-btn {
                 display: block;
             }
         }

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -677,11 +677,11 @@ body {
         white-space: nowrap;
 
         .left-align-btn, .center-align-btn, .right-align-btn {
-            width: 48px;
-            height: 48px;
+            width: 20px;
+            height: 20px;
             position: absolute;
             right: 0;
-            top: 3px;
+            top: 0;
             padding: 4px;
             cursor: pointer;
             display: none;

--- a/src/charts/heavyai-table.js
+++ b/src/charts/heavyai-table.js
@@ -94,7 +94,9 @@ export default function heavyaiTable(parent, chartGroup) {
   }
 
   _chart.isColLeftAligned = function(colIndex) {
-    return _columnAlignments[colIndex] === "left" || !_columnAlignments[colIndex]
+    return (
+      _columnAlignments[colIndex] === "left" || !_columnAlignments[colIndex]
+    )
   }
 
   _chart.isColCenterAligned = function(colIndex) {
@@ -551,9 +553,7 @@ export default function heavyaiTable(parent, chartGroup) {
         })
         .style(
           "left",
-          headerItem.node().getBoundingClientRect().width -
-          54 +
-          "px"
+          headerItem.node().getBoundingClientRect().width - 54 + "px"
         )
         .append("svg")
         .attr("class", "svg-icon")
@@ -576,9 +576,7 @@ export default function heavyaiTable(parent, chartGroup) {
         })
         .style(
           "left",
-          headerItem.node().getBoundingClientRect().width -
-          36 +
-          "px"
+          headerItem.node().getBoundingClientRect().width - 36 + "px"
         )
         .append("svg")
         .attr("class", "svg-icon")
@@ -601,9 +599,7 @@ export default function heavyaiTable(parent, chartGroup) {
         })
         .style(
           "left",
-          headerItem.node().getBoundingClientRect().width -
-          18 +
-          "px"
+          headerItem.node().getBoundingClientRect().width - 18 + "px"
         )
         .append("svg")
         .attr("class", "svg-icon")

--- a/src/charts/heavyai-table.js
+++ b/src/charts/heavyai-table.js
@@ -552,7 +552,7 @@ export default function heavyaiTable(parent, chartGroup) {
         .style(
           "left",
           headerItem.node().getBoundingClientRect().width -
-          60 +
+          54 +
           "px"
         )
         .append("svg")
@@ -577,7 +577,7 @@ export default function heavyaiTable(parent, chartGroup) {
         .style(
           "left",
           headerItem.node().getBoundingClientRect().width -
-          40 +
+          36 +
           "px"
         )
         .append("svg")
@@ -602,7 +602,7 @@ export default function heavyaiTable(parent, chartGroup) {
         .style(
           "left",
           headerItem.node().getBoundingClientRect().width -
-          20 +
+          18 +
           "px"
         )
         .append("svg")

--- a/src/charts/heavyai-table.js
+++ b/src/charts/heavyai-table.js
@@ -552,7 +552,7 @@ export default function heavyaiTable(parent, chartGroup) {
         .style(
           "left",
           headerItem.node().getBoundingClientRect().width -
-          (48 * 3) +
+          (GROUP_DATA_WIDTH * 3) +
           "px"
         )
         .append("svg")
@@ -577,7 +577,7 @@ export default function heavyaiTable(parent, chartGroup) {
         .style(
           "left",
           headerItem.node().getBoundingClientRect().width -
-          (48 * 2) +
+          (GROUP_DATA_WIDTH * 1.5) +
           "px"
         )
         .append("svg")
@@ -602,7 +602,7 @@ export default function heavyaiTable(parent, chartGroup) {
         .style(
           "left",
           headerItem.node().getBoundingClientRect().width -
-          48 +
+          GROUP_DATA_WIDTH +
           "px"
         )
         .append("svg")

--- a/src/charts/heavyai-table.js
+++ b/src/charts/heavyai-table.js
@@ -32,13 +32,14 @@ export default function heavyaiTable(parent, chartGroup) {
   let _crossfilter = null
   let _tableFilter = null
   let _sortColumn = null
+  let _columnAlignments = []
   let _dimOrGroup = null
   let _isGroupedData = false
   let _colAliases = null
   let _sampling = false
   let _nullsOrder = ""
 
-  const _table_events = ["sort"]
+  const _table_events = ["sort", "align"]
   const _listeners = d3.dispatch.apply(d3, _table_events)
   const _on = _chart.on.bind(_chart)
 
@@ -54,6 +55,12 @@ export default function heavyaiTable(parent, chartGroup) {
   _chart._invokeSortListener = function(f) {
     if (f !== "undefined") {
       _listeners.sort(_chart, f)
+    }
+  }
+
+  _chart._invokeAlignListener = function(f) {
+    if (f !== "undefined") {
+      _listeners.align(_chart, f)
     }
   }
 
@@ -76,6 +83,26 @@ export default function heavyaiTable(parent, chartGroup) {
     }
     _sortColumn = _
     return _chart
+  }
+
+  _chart.columnAlignments = function(_) {
+    if (!arguments.length) {
+      return _columnAlignments
+    }
+    _columnAlignments = _
+    return _chart
+  }
+
+  _chart.isColLeftAligned = function(colIndex) {
+    return _columnAlignments[colIndex] === "left" || !_columnAlignments[colIndex]
+  }
+
+  _chart.isColCenterAligned = function(colIndex) {
+    return _columnAlignments[colIndex] === "center"
+  }
+
+  _chart.isColRightAligned = function(colIndex) {
+    return _columnAlignments[colIndex] === "right"
   }
 
   _chart.nullsOrder = function(_) {
@@ -349,7 +376,7 @@ export default function heavyaiTable(parent, chartGroup) {
       return tableRowCls
     })
 
-    cols.forEach(col => {
+    cols.forEach((col, i) => {
       rowItem
         .append("td")
         .html(d => {
@@ -372,6 +399,9 @@ export default function heavyaiTable(parent, chartGroup) {
           )
         })
         .classed("filtered", col.expression in _filteredColumns)
+        .classed("cell-align-left", () => _chart.isColLeftAligned(i))
+        .classed("cell-align-center", () => _chart.isColCenterAligned(i))
+        .classed("cell-align-right", () => _chart.isColRightAligned(i))
         .on("click", d => {
           // detect if user is selecting text or clicking a value, if so don't filter data
           const s = window.getSelection().toString()
@@ -506,6 +536,63 @@ export default function heavyaiTable(parent, chartGroup) {
         .attr("viewBox", "0 0 48 48")
         .append("use")
         .attr("xlink:href", "#icon-arrow1")
+
+      // left align button
+      headerItem
+        .append("div")
+        .attr("class", "left-align-btn")
+        .classed("active", () => _chart.isColLeftAligned(i))
+        .on("click", () => {
+          if (!_chart.isColLeftAligned(i)) {
+            _columnAlignments[i] = "left"
+            _chart._invokeAlignListener(_columnAlignments)
+            _chart.redrawAsync()
+          }
+        })
+        .append("svg")
+        .attr("class", "svg-icon")
+        .classed("icon-caret-left", true)
+        .attr("viewBox", "0 0 48 48")
+        .append("use")
+        .attr("xlink:href", "#icon-caret-left")
+
+      // center align button
+      headerItem
+        .append("div")
+        .attr("class", "center-align-btn")
+        .classed("active", () => _chart.isColCenterAligned(i))
+        .on("click", () => {
+          if (!_chart.isColCenterAligned(i)) {
+            _columnAlignments[i] = "left"
+            _chart._invokeAlignListener(_columnAlignments)
+            _chart.redrawAsync()
+          }
+        })
+        .append("svg")
+        .attr("class", "svg-icon")
+        .classed("icon-align-center", true)
+        .attr("viewBox", "0 0 48 48")
+        .append("use")
+        .attr("xlink:href", "#icon-align-center")
+
+      // right align button
+      headerItem
+        .append("div")
+        .attr("class", "right-align-btn")
+        .classed("active", () => _chart.isColRightAligned(i))
+        .on("click", () => {
+          if (!_chart.isColRightAligned(i)) {
+            _columnAlignments[i] = "right"
+            _chart._invokeAlignListener(_columnAlignments)
+            _chart.redrawAsync()
+          }
+        })
+        .append("svg")
+        .attr("class", "svg-icon")
+        .classed("icon-caret-right", true)
+        .attr("viewBox", "0 0 48 48")
+        .append("use")
+        .attr("xlink:href", "#icon-caret-right")
 
       headerItem
         .append("div")

--- a/src/charts/heavyai-table.js
+++ b/src/charts/heavyai-table.js
@@ -549,6 +549,12 @@ export default function heavyaiTable(parent, chartGroup) {
             _chart.redrawAsync()
           }
         })
+        .style(
+          "left",
+          headerItem.node().getBoundingClientRect().width -
+          (48 * 3) +
+          "px"
+        )
         .append("svg")
         .attr("class", "svg-icon")
         .classed("icon-caret-left", true)
@@ -568,6 +574,12 @@ export default function heavyaiTable(parent, chartGroup) {
             _chart.redrawAsync()
           }
         })
+        .style(
+          "left",
+          headerItem.node().getBoundingClientRect().width -
+          (48 * 2) +
+          "px"
+        )
         .append("svg")
         .attr("class", "svg-icon")
         .classed("icon-align-center", true)
@@ -587,6 +599,12 @@ export default function heavyaiTable(parent, chartGroup) {
             _chart.redrawAsync()
           }
         })
+        .style(
+          "left",
+          headerItem.node().getBoundingClientRect().width -
+          48 +
+          "px"
+        )
         .append("svg")
         .attr("class", "svg-icon")
         .classed("icon-caret-right", true)

--- a/src/charts/heavyai-table.js
+++ b/src/charts/heavyai-table.js
@@ -552,7 +552,7 @@ export default function heavyaiTable(parent, chartGroup) {
         .style(
           "left",
           headerItem.node().getBoundingClientRect().width -
-          (GROUP_DATA_WIDTH * 3) +
+          (GROUP_DATA_WIDTH * 2) +
           "px"
         )
         .append("svg")
@@ -569,7 +569,7 @@ export default function heavyaiTable(parent, chartGroup) {
         .classed("active", () => _chart.isColCenterAligned(i))
         .on("click", () => {
           if (!_chart.isColCenterAligned(i)) {
-            _columnAlignments[i] = "left"
+            _columnAlignments[i] = "center"
             _chart._invokeAlignListener(_columnAlignments)
             _chart.redrawAsync()
           }

--- a/src/charts/heavyai-table.js
+++ b/src/charts/heavyai-table.js
@@ -552,13 +552,13 @@ export default function heavyaiTable(parent, chartGroup) {
         .style(
           "left",
           headerItem.node().getBoundingClientRect().width -
-          (GROUP_DATA_WIDTH * 2) +
+          60 +
           "px"
         )
         .append("svg")
         .attr("class", "svg-icon")
         .classed("icon-caret-left", true)
-        .attr("viewBox", "0 0 48 48")
+        .attr("viewBox", "0 0 16 16")
         .append("use")
         .attr("xlink:href", "#icon-caret-left")
 
@@ -577,13 +577,13 @@ export default function heavyaiTable(parent, chartGroup) {
         .style(
           "left",
           headerItem.node().getBoundingClientRect().width -
-          (GROUP_DATA_WIDTH * 1.5) +
+          40 +
           "px"
         )
         .append("svg")
         .attr("class", "svg-icon")
         .classed("icon-align-center", true)
-        .attr("viewBox", "0 0 48 48")
+        .attr("viewBox", "0 0 16 16")
         .append("use")
         .attr("xlink:href", "#icon-align-center")
 
@@ -602,13 +602,13 @@ export default function heavyaiTable(parent, chartGroup) {
         .style(
           "left",
           headerItem.node().getBoundingClientRect().width -
-          GROUP_DATA_WIDTH +
+          20 +
           "px"
         )
         .append("svg")
         .attr("class", "svg-icon")
         .classed("icon-caret-right", true)
-        .attr("viewBox", "0 0 48 48")
+        .attr("viewBox", "0 0 16 16")
         .append("use")
         .attr("xlink:href", "#icon-caret-right")
 


### PR DESCRIPTION
This adds functionality to the table chart that allows the user to specify content alignment on a per-column basis. The buttons appear when you hover over the column, and can be accessed/manipulated via `chart.columnAlignments()`

Work will be done in Immerse to persist/populate this settings in the dashboard state.

[JIRA](https://heavyai.atlassian.net/browse/FE-15044)


<img width="263" alt="CleanShot 2022-03-25 at 12 43 33@2x" src="https://user-images.githubusercontent.com/8716214/160173870-e02a9c00-5959-4354-8886-f51a46573e64.png">