### PR TITLE
[FE-16027] Use parser to create filters, and apply to contour query

### DIFF
--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -340,7 +340,6 @@ export default function rasterLayerLineMixin(_layer) {
 
   _layer.__genVega = function({
     table,
-    mapBounds,
     filter,
     lastFilteredSize,
     globalFilter,
@@ -361,7 +360,17 @@ export default function rasterLayerLineMixin(_layer) {
 
     let sql
     if (isContourType(state)) {
-      sql = buildContourSQL(state.data[0], mapBounds)
+      const filterTransforms = _layer.getTransforms(
+        table,
+        filter,
+        globalFilter,
+        state,
+        lastFilteredSize
+      ).filter((f) => f.type === "filter")
+      sql = buildContourSQL({
+        state: state.data[0], 
+        filterTransforms
+      })
     } else {
       sql = parser.writeSQL({
         type: "root",
@@ -486,10 +495,8 @@ export default function rasterLayerLineMixin(_layer) {
         })
     }
 
-    const mapBounds = chart.map().getBounds()
     _vega = _layer.__genVega({
       layerName,
-      mapBounds,
       table: _layer.crossfilter().getTable()[0],
       filter: _layer.crossfilter().getFilterString(layerName),
       globalFilter: _layer.crossfilter().getGlobalFilterString(),

--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -363,15 +363,11 @@ export default function rasterLayerLineMixin(_layer) {
     let sql
     if (isContourType(state)) {
       validateContourState(state)
-      const filterTransforms = _layer.getTransforms(
-        table,
-        filter,
-        globalFilter,
-        state,
-        lastFilteredSize
-      ).filter((f) => f.type === "filter")
+      const filterTransforms = _layer
+        .getTransforms(table, filter, globalFilter, state, lastFilteredSize)
+        .filter(f => f.type === "filter")
       sql = buildContourSQL({
-        state: state.data[0], 
+        state: state.data[0],
         filterTransforms
       })
     } else {

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -531,8 +531,20 @@ export default function rasterLayerPolyMixin(_layer) {
 
     let data
     if (isContourType(state)) {
-      const mapBounds = chart.map().getBounds()
-      const sql = buildContourSQL(state.data[0], mapBounds, true)
+      const filterTransforms = _layer.getTransforms({
+        bboxFilter,
+        filter,
+        globalFilter,
+        layerFilter,
+        filtersInverse,
+        state,
+        lastFilteredSize
+      }).filter((f) => f.type === "filter")
+      const sql = buildContourSQL({
+        state: state.data[0],
+        filterTransforms,
+        isPolygons: true
+      })
       data = [
         {
           name: layerName,

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -531,15 +531,17 @@ export default function rasterLayerPolyMixin(_layer) {
 
     let data
     if (isContourType(state)) {
-      const filterTransforms = _layer.getTransforms({
-        bboxFilter,
-        filter,
-        globalFilter,
-        layerFilter,
-        filtersInverse,
-        state,
-        lastFilteredSize
-      }).filter((f) => f.type === "filter")
+      const filterTransforms = _layer
+        .getTransforms({
+          bboxFilter,
+          filter,
+          globalFilter,
+          layerFilter,
+          filtersInverse,
+          state,
+          lastFilteredSize
+        })
+        .filter(f => f.type === "filter")
       const sql = buildContourSQL({
         state: state.data[0],
         filterTransforms,

--- a/src/utils/utils-contour.js
+++ b/src/utils/utils-contour.js
@@ -24,7 +24,11 @@ const buildParamsSQL = (params = {}) =>
     }, [])
     .join(", ")
 
-export const buildContourSQL = (state, mapBounds, isPolygons = false) => {
+export const buildContourSQL = ({
+  state,
+  filterTransforms = [],
+  isPolygons = false
+}) => {
   const {
     table,
     minor_contour_interval,
@@ -52,14 +56,13 @@ export const buildContourSQL = (state, mapBounds, isPolygons = false) => {
     flip_latitude
   }
 
-  const rasterSelectFilter = mapBounds
-    ? `where ${lat_field} >= ${mapBounds._sw.lat} AND ${lat_field} <= ${mapBounds._ne.lat} AND ${lon_field} >= ${mapBounds._sw.lng} AND ${lon_field} <= ${mapBounds._ne.lng}`
-    : ""
+  const rasterSelectFilter = filterTransforms.length ? `where ${filterTransforms.map(ft => ft.expr).join("AND")}` : ""
   const rasterSelect = `select ${lon_field}, ${lat_field},  ${contour_value_field} from ${table} ${rasterSelectFilter}`
 
   // Transform params object into 'param_name' => 'param_value', ... for sql query
   const contourParamsSQL = buildParamsSQL(contourParams)
 
+  // TODO: Use geocol here
   const geometryColumn = isPolygons ? "contour_polygons" : "contour_lines"
   const contourLineCase = `CASE mod(cast(contour_values as int), ${major_contour_interval}) WHEN 0 THEN 1 ELSE 0 END as is_major `
   const contourTableFunction = isPolygons

--- a/src/utils/utils-contour.js
+++ b/src/utils/utils-contour.js
@@ -73,7 +73,7 @@ export const buildContourSQL = ({
   }
 
   const rasterSelectFilter = filterTransforms.length
-    ? `where ${filterTransforms.map((ft) => ft.expr).join("AND")}`
+    ? `where ${filterTransforms.map(ft => ft.expr).join("AND")}`
     : ""
   const rasterSelect = `select ${lon_field}, ${lat_field},  ${contour_value_field} from ${table} ${rasterSelectFilter}`
 
@@ -147,7 +147,7 @@ export const getContourScales = ({ strokeWidth, opacity, color }) => {
   ]
 }
 
-export const validateContourState = (state) => {
+export const validateContourState = state => {
   if (!state.data || !state.data.length) {
     throw new Error("Contour layer requires exactly 1 item in the data list")
   }


### PR DESCRIPTION
# Description
Since we can't use the parser to generate the sql for the contour TF, it also wasn't including the layer/global filters in the custom contour util. This takes _just_ the filters from the parser and adds those to the contour query

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
