### PR TITLE
Bad merge fix

### DIFF
--- a/dist/charting.css
+++ b/dist/charting.css
@@ -1015,18 +1015,18 @@ body {
       animation: fadeInMapPoint .5s; }
     .dc-chart .map-poly.fadeOutPoly {
       animation: fadeOutMapPoint .25s; }
-  .dc-chart .map-polyline {
+  .dc-chart .map-polyline g {
     fill: none;
     stroke: #ffffff;
     stroke-width: 4;
     pointer-events: none; }
-    .dc-chart .map-polyline.popupPoly {
+    .dc-chart .map-polyline g.popupPoly {
       animation: showMapPoint .5s; }
-    .dc-chart .map-polyline.removePoly {
+    .dc-chart .map-polyline g.removePoly {
       animation: hideMapPoint .25s; }
-    .dc-chart .map-polyline.fadeInPoly {
+    .dc-chart .map-polyline g.fadeInPoly {
       animation: fadeInMapPoint .5s; }
-    .dc-chart .map-polyline.fadeOutPoly {
+    .dc-chart .map-polyline g.fadeOutPoly {
       animation: fadeOutMapPoint .25s; }
 
 @keyframes showMapPopup {

--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -367,7 +367,7 @@ export default function rasterLayerLineMixin(_layer) {
         .getTransforms(table, filter, globalFilter, state, lastFilteredSize)
         .filter(f => f.type === "filter")
       sql = buildContourSQL({
-        state: state.data[0],
+        state,
         filterTransforms
       })
     } else {

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -543,7 +543,7 @@ export default function rasterLayerPolyMixin(_layer) {
         })
         .filter(f => f.type === "filter")
       const sql = buildContourSQL({
-        state: state.data[0],
+        state,
         filterTransforms,
         isPolygons: true
       })


### PR DESCRIPTION
`buildContourSQL` expecting all of the chart `state`, but charting passing just the contour data. Crossed wires somewhere, this gets them on the same page. 

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
