### PR TITLE
Auto fills continuous scale domains to align with number of ranges.

### DIFF
--- a/src/mixins/render-vega-lite/Definitions/Encoding/Scale/Continuous/ContinuousScale.js
+++ b/src/mixins/render-vega-lite/Definitions/Encoding/Scale/Continuous/ContinuousScale.js
@@ -74,6 +74,9 @@ export default class ContinuousScale extends ScaleDefinitionObject {
     }
   }
 
+  // eslint-disable-next-line no-undef
+  static max_subdivisions = 25
+
   /**
    * @param {string} field_output
    * @param {string} layer_name
@@ -90,6 +93,7 @@ export default class ContinuousScale extends ScaleDefinitionObject {
     extent_flags,
     num_subdivisions = 0
   ) {
+    assert(num_subdivisions <= ContinuousScale.max_subdivisions)
     return ExtentFlags.buildVegaTransformFromExtentFlags(
       field_output,
       layer_name,
@@ -179,6 +183,16 @@ export default class ContinuousScale extends ScaleDefinitionObject {
        */
       const parent = this.parent
       assert(parent instanceof FieldDefinitionObject)
+
+      const num_subdivisions = this.range_.length - 2
+      if (num_subdivisions > ContinuousScale.max_subdivisions) {
+        throw new Error(
+          `There are too many ranges (${
+            this.range_.length
+          }) to auto-fill a domain. The max number of ranges is ${ContinuousScale.max_subdivisions +
+            2}`
+        )
+      }
 
       const {
         vega_xform_obj,

--- a/src/mixins/render-vega-lite/Definitions/Encoding/Scale/Discretizing/DiscretizingScale.js
+++ b/src/mixins/render-vega-lite/Definitions/Encoding/Scale/Discretizing/DiscretizingScale.js
@@ -109,6 +109,6 @@ export default class DiscretizingScale extends ScaleDefinitionObject {
    */
   // eslint-disable-next-line no-unused-vars
   _materializeExtraVegaScaleProps(prop_descriptor, vega_scale_object) {
-    assert(false)
+    // no-op
   }
 }

--- a/src/mixins/render-vega-lite/Definitions/Encoding/Scale/Discretizing/ThresholdScale.js
+++ b/src/mixins/render-vega-lite/Definitions/Encoding/Scale/Discretizing/ThresholdScale.js
@@ -113,14 +113,6 @@ export default class ThresholdScale extends DiscretizingScale {
         }
       )
 
-      ContinuousScale.buildExtentsVegaTransform(
-        parent.output,
-        this.root_context.layer_name,
-        prop_descriptor.prop_name,
-        // should equate to: [max(min, avg - 2*stddev), min(max, avg + 2*stddev)]
-        ExtentFlags.kMin | ExtentFlags.kMax | ExtentFlags.kTwoSigma
-      )
-
       vega_property_output_state.addVegaTransform(
         prop_descriptor.prop_name,
         vega_xform_obj


### PR DESCRIPTION
The list of ranges for continuous scales (max of 25 ranges) will now be used to auto-fill in domains. Before it would only use the first two range values in the list and ignore the rest. Now, all ranges will have an associated domain value, therefore all range values will be represented in the scale. This is achieved by filling in a new vega formula expression for each "stop"/"subdivision" in the range list.

Opportunistically fixed some other minor issues as well.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
