### PR TITLE
Update mapd-draw dependency to latest commit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,8 +127,8 @@
       }
     },
     "@heavyai/draw": {
-      "version": "git+https://github.com/omnisci/mapd-draw.git#85f440feee154fd9344113de48cecfab89d05274",
-      "from": "git+https://github.com/omnisci/mapd-draw.git#85f440f",
+      "version": "git+https://github.com/heavyai/mapd-draw.git#fc0b065fb9e268e7aa3c6add3985ec630a6e83a5",
+      "from": "git+https://github.com/heavyai/mapd-draw.git#fc0b065",
       "requires": {
         "css-element-queries": "^0.4.0",
         "gl-matrix": "^2.3.2"
@@ -216,14 +216,6 @@
     "@mapd/crossfilter": {
       "version": "github:omnisci/mapd-crossfilter#6f291acdef3c0c79f3b12cea35bd3313423aa303",
       "from": "github:omnisci/mapd-crossfilter#6f291ac"
-    },
-    "@mapd/mapd-draw": {
-      "version": "git+https://github.com/omnisci/mapd-draw.git#85f440feee154fd9344113de48cecfab89d05274",
-      "from": "git+https://github.com/omnisci/mapd-draw.git#85f440f",
-      "requires": {
-        "css-element-queries": "^0.4.0",
-        "gl-matrix": "^2.3.2"
-      }
     },
     "@sindresorhus/is": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -54,11 +54,10 @@
   },
   "dependencies": {
     "@heavyai/data-layer": "npm:mapd-data-layer-2@0.0.25",
-    "@heavyai/draw": "https://github.com/omnisci/mapd-draw.git#85f440f",
+    "@heavyai/draw": "https://github.com/heavyai/mapd-draw.git#fc0b065",
     "@mapbox/unitbezier": "0.0.0",
     "@mapd/connector": "github:omnisci/mapd-connector#d75148077a2a4b23d66d89c63d05c20e5735af2e",
     "@mapd/crossfilter": "github:omnisci/mapd-crossfilter#6f291ac",
-    "@mapd/mapd-draw": "git+https://github.com/omnisci/mapd-draw.git#85f440f",
     "@turf/bbox": "^6.5.0",
     "@turf/bbox-clip": "^6.5.0",
     "axios": "^0.19.2",

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -16,7 +16,6 @@ import { Legend } from "legendables"
 import * as _ from "lodash"
 import { paused } from "../constants/paused"
 import { shallowCopyVega } from "../utils/utils-vega"
-import * as HeavyConnect from "@heavyai/connector"
 import assert from "assert"
 
 export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
@@ -697,18 +696,18 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
     callback,
     fetchEvenIfEmpty = false
   ) {
+    if (!point) {
+      return
+    }
+
     const height =
       typeof _chart.effectiveHeight === "function"
         ? _chart.effectiveHeight()
         : _chart.height()
     const pixelRatio = _chart._getPixelRatio() || 1
-    const pixel = new HeavyConnect.TPixel({
+    const pixel = {
       x: Math.round(point.x * pixelRatio),
       y: Math.round((height - point.y) * pixelRatio)
-    })
-
-    if (!point) {
-      return
     }
 
     let cnt = 0

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -16,6 +16,7 @@ import { Legend } from "legendables"
 import * as _ from "lodash"
 import { paused } from "../constants/paused"
 import { shallowCopyVega } from "../utils/utils-vega"
+import * as HeavyConnect from "@heavyai/connector"
 import assert from "assert"
 
 export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
@@ -701,7 +702,7 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
         ? _chart.effectiveHeight()
         : _chart.height()
     const pixelRatio = _chart._getPixelRatio() || 1
-    const pixel = new TPixel({
+    const pixel = new HeavyConnect.TPixel({
       x: Math.round(point.x * pixelRatio),
       y: Math.round((height - point.y) * pixelRatio)
     })

--- a/src/mixins/raster-draw-mixin.js
+++ b/src/mixins/raster-draw-mixin.js
@@ -1,7 +1,7 @@
 import * as LatLonUtils from "../utils/utils-latlon"
 import LassoButtonGroupController from "./ui/lasso-tool-ui"
 import * as _ from "lodash"
-import * as Draw from "@heavyai/draw/dist/mapd-draw"
+import * as Draw from "@heavyai/draw/dist/draw"
 import { redrawAllAsync } from "../core/core-async"
 import LatLonCircle from "./ui/lasso-shapes/LatLonCircle"
 import LatLonPoly from "./ui/lasso-shapes/LatLonPoly"

--- a/src/mixins/raster-layer-mesh2d-mixin.js
+++ b/src/mixins/raster-layer-mesh2d-mixin.js
@@ -1,6 +1,6 @@
 import assert from "assert"
 import { parser } from "../utils/utils"
-import { AABox2d } from "@heavyai/draw/dist/mapd-draw"
+import { AABox2d } from "@heavyai/draw/dist/draw"
 import { lastFilteredSize } from "../core/core-async"
 import { createRasterLayerGetterSetter } from "../utils/utils-vega"
 import { isValidPostFilter } from "./raster-layer-point-mixin"

--- a/src/mixins/raster-layer-point-mixin.js
+++ b/src/mixins/raster-layer-point-mixin.js
@@ -9,7 +9,7 @@ import {
 } from "../utils/utils-vega"
 import { parser } from "../utils/utils"
 import * as d3 from "d3"
-import { AABox2d, Point2d } from "@heavyai/draw/dist/mapd-draw"
+import { AABox2d, Point2d } from "@heavyai/draw/dist/draw"
 
 const AUTOSIZE_DOMAIN_DEFAULTS = [100000, 0]
 const AUTOSIZE_RANGE_DEFAULTS = [2.0, 5.0]

--- a/src/mixins/raster-layer-windbarb-mixin.js
+++ b/src/mixins/raster-layer-windbarb-mixin.js
@@ -2,7 +2,7 @@ import { lastFilteredSize } from "../core/core-async"
 import { createRasterLayerGetterSetter } from "../utils/utils-vega"
 import { parser } from "../utils/utils"
 import { AGGREGATES, isValidPostFilter } from "./raster-layer-point-mixin"
-import { AABox2d } from "@heavyai/draw/dist/mapd-draw"
+import { AABox2d } from "@heavyai/draw/dist/draw"
 import {
   ColorChannelDescriptor,
   OpacityChannelDescriptor,

--- a/src/mixins/raster-layer.js
+++ b/src/mixins/raster-layer.js
@@ -9,7 +9,7 @@ import {
   createRasterLayerGetterSetter,
   createVegaAttrMixin
 } from "../utils/utils-vega"
-import { AABox2d, Point2d } from "@heavyai/draw/dist/mapd-draw"
+import { AABox2d, Point2d } from "@heavyai/draw/dist/draw"
 import moment from "moment"
 
 const validLayerTypes = [

--- a/src/mixins/ui/lasso-shapes/LatLonCircle.js
+++ b/src/mixins/ui/lasso-shapes/LatLonCircle.js
@@ -1,7 +1,7 @@
 "use strict"
 
 import * as LatLonUtils from "../../../utils/utils-latlon"
-import * as Draw from "@heavyai/draw/dist/mapd-draw"
+import * as Draw from "@heavyai/draw/dist/draw"
 import LatLonViewIntersectUtils from "./LatLonViewIntersectUtils"
 
 const { AABox2d, Mat2d, Point2d, Vec2d } = Draw

--- a/src/mixins/ui/lasso-shapes/LatLonPoly.js
+++ b/src/mixins/ui/lasso-shapes/LatLonPoly.js
@@ -1,7 +1,7 @@
 "use strict"
 
 import * as LatLonUtils from "../../../utils/utils-latlon"
-import * as Draw from "@heavyai/draw/dist/mapd-draw"
+import * as Draw from "@heavyai/draw/dist/draw"
 import LatLonViewIntersectUtils from "./LatLonViewIntersectUtils"
 
 const { AABox2d, Mat2d, Point2d } = Draw

--- a/src/mixins/ui/lasso-shapes/LatLonViewIntersectUtils.js
+++ b/src/mixins/ui/lasso-shapes/LatLonViewIntersectUtils.js
@@ -1,7 +1,7 @@
 "use strict"
 
 import * as LatLonUtils from "../../../utils/utils-latlon"
-import * as Draw from "@heavyai/draw/dist/mapd-draw"
+import * as Draw from "@heavyai/draw/dist/draw"
 
 const { AABox2d, Mat2d, Point2d, Vec2d } = Draw
 const MathExt = Draw.Math

--- a/src/mixins/ui/lasso-tool-ui.js
+++ b/src/mixins/ui/lasso-tool-ui.js
@@ -1,7 +1,7 @@
 "use strict"
 
 import * as LatLonUtils from "../../utils/utils-latlon"
-import * as Draw from "@heavyai/draw/dist/mapd-draw"
+import * as Draw from "@heavyai/draw/dist/draw"
 import simplify from "simplify-js"
 import { logger } from "../../utils/logger"
 import LatLonCircle from "./lasso-shapes/LatLonCircle"

--- a/src/utils/utils-latlon.js
+++ b/src/utils/utils-latlon.js
@@ -1,6 +1,6 @@
 "use strict"
 
-import * as Draw from "@heavyai/draw/dist/mapd-draw"
+import * as Draw from "@heavyai/draw/dist/draw"
 
 /**
  * Calculates the distance in meters between two lon/lat coordinates

--- a/src/utils/utils-vega.js
+++ b/src/utils/utils-vega.js
@@ -1,6 +1,6 @@
 import d3 from "d3"
 import wellknown from "wellknown"
-import { AABox2d, Point2d, PolyLine } from "@heavyai/draw/dist/mapd-draw"
+import { AABox2d, Point2d, PolyLine } from "@heavyai/draw/dist/draw"
 export function notNull(value) {
   return value != null /* double-equals also catches undefined */
 }


### PR DESCRIPTION
Prior, the commit the mapd-draw dependency was pointing to was pre-rebranding efforts, so to move to a top-of-branch commit meant we needed to update all the mapd-draw-related import statements to reflect the rebrand-related naming. So paths such as `@heavyai/draw/dist/mapd-draw` needed to be updated to `@heavyai/draw/dist/draw`

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
