### PR TITLE
[FE-16114][FE-16108] Contour error on layer destroy, add contour case for bounding box query

### DIFF
--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -717,17 +717,25 @@ export default function rasterLayerPolyMixin(_layer) {
   _layer._genVega = function(chart, layerName) {
     let polyFilterString = ""
     let bboxFilter = ""
-    if (!isContourType(_layer.getState())) {
       const mapBounds = chart.map().getBounds()
 
       const state = _layer.getState()
-      const columnExpr = `${state.encoding.geoTable}.${state.encoding.geocol}`
-
-      bboxFilter = `ST_XMax(${columnExpr}) >= ${mapBounds._sw.lng} AND ST_XMin(${columnExpr}) <= ${mapBounds._ne.lng} AND ST_YMax(${columnExpr}) >= ${mapBounds._sw.lat} AND ST_YMin(${columnExpr}) <= ${mapBounds._ne.lat}`
+      const data = state.data[0]
+      if (isContourType(_layer.getState()) && data) {
+        
+        const table = data.table
+        const isGeoPoint = data.is_geo_point_type
+        const latField = isGeoPoint ? `ST_Y(${table}.${data.lat_field})` : `${table}.${data.lat_field}`
+        const lonField = isGeoPoint ? `ST_X${data.lon_field}` : `${table}.${data.lon_field}`
+        bboxFilter = `${lonField} >= ${mapBounds._sw.lng} AND ${lonField} <= ${mapBounds._ne.lng} AND ${latField} >= ${mapBounds._sw.lat} AND ${latField} <= ${mapBounds._ne.lat}`
+      } else {
+        const columnExpr = `${state.encoding.geoTable}.${state.encoding.geocol}`
+        bboxFilter = `ST_XMax(${columnExpr}) >= ${mapBounds._sw.lng} AND ST_XMin(${columnExpr}) <= ${mapBounds._ne.lng} AND ST_YMax(${columnExpr}) >= ${mapBounds._sw.lat} AND ST_YMin(${columnExpr}) <= ${mapBounds._ne.lat}`
+      }
 
       const allFilters = _layer.crossfilter().getFilter(layerName)
       const otherChartFilters = allFilters.filter(
-        (f, i) =>
+        (f, i) => !_layer.dimension() || 
           i !== _layer.dimension().getDimensionIndex() && f !== "" && f !== null
       )
 
@@ -740,7 +748,6 @@ export default function rasterLayerPolyMixin(_layer) {
         firstElem = false
         polyFilterString += value
       })
-    }
 
     _vega = _layer.__genVega({
       chart,
@@ -819,12 +826,12 @@ export default function rasterLayerPolyMixin(_layer) {
       }`
     }
 
-    if (_filtersArray.length === 1 && filterCol) {
+    if (_filtersArray.length === 1 && filterCol && _layer.dimension()) {
       _layer.dimension().set(() => [filterCol])
       _layer.viewBoxDim(null)
     }
 
-    if (_filtersArray.length && filterCol) {
+    if (_filtersArray.length && filterCol && _layer.dimension()) {
       _layer.dimension().filterMulti(_filtersArray, undefined, isInverseFilter)
     } else {
       _layer.filterAll(chart)
@@ -837,24 +844,28 @@ export default function rasterLayerPolyMixin(_layer) {
 
   _layer.filterAll = function(chart) {
     _filtersArray = []
-    _layer.dimension().filterAll()
-    const geoCol = `${_layer.getState().encoding.geoTable}.${
-      _layer.getState().encoding.geocol
-    }`
-
-    // when poly selection filter cleared, we reapply the bbox filter for the NON geo joined poly
-    // For geo joined poly, we don't run crossfilter
-    if (_layer && _layer.getState().data && _layer.getState().data.length < 2) {
-      const viewboxdim = _layer.dimension().set(() => [geoCol])
-      const mapBounds = chart.map().getBounds()
-      _layer.viewBoxDim(viewboxdim)
-      _layer.viewBoxDim().filterST_Min_ST_Max({
-        lonMin: mapBounds._sw.lng,
-        lonMax: mapBounds._ne.lng,
-        latMin: mapBounds._sw.lat,
-        latMax: mapBounds._ne.lat
-      })
+    if (_layer.dimension()) {
+      _layer.dimension().filterAll()
     }
+    const geoTable = _layer.getState().encoding.geoTable
+    const geoCol = _layer.getState().encoding.geocol
+    if (geoTable && geoCol) {
+      const geoTableCol = `${geoTable}.${geoCol}`
+      // when poly selection filter cleared, we reapply the bbox filter for the NON geo joined poly
+      // For geo joined poly, we don't run crossfilter
+      if (_layer && _layer.getState().data && _layer.getState().data.length < 2) {
+        const viewboxdim = _layer.dimension().set(() => [geoTableCol])
+        const mapBounds = chart.map().getBounds()
+        _layer.viewBoxDim(viewboxdim)
+        _layer.viewBoxDim().filterST_Min_ST_Max({
+          lonMin: mapBounds._sw.lng,
+          lonMax: mapBounds._ne.lng,
+          latMin: mapBounds._sw.lat,
+          latMax: mapBounds._ne.lat
+        })
+      }
+    }
+    
 
     _listeners.filtered(_layer, _filtersArray)
   }


### PR DESCRIPTION
Two bugs:
[FE-16114] - Contour layer throws errors when trying to destroy the layer which causes problems when removing required measures/dimensions. Poly layer mixin assumes dimension() exists, but not the case for contours. This just makes sure that dimension() exists before chaining.
[FE-16108] - Contour layer skipped bounding box query during initial implementation, this adds the special contour case to make sure viewport bounding box is included in the query.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
