### PR TITLE
Enforces cross-section line draw rule by only allowing one drawn cross section at a time

### DIFF
--- a/example/exampleLineCrossSection.js
+++ b/example/exampleLineCrossSection.js
@@ -233,18 +233,11 @@ function create_charts(
         LassoGlobalEventConstants.LASSO_SHAPE_CREATE,
         event_obj => {
           if (cross_section_layer) {
-            const { shape } = event_obj
-            if (shape instanceof LatLonPolyLine) {
-              // if the newly created lasso shape is a 'LatLonPolyLine', which is
-              // the current name of a cross section line shape, then attach an
-              // edit callback to it to capture any/all edits after creation.
-
-              // TODO(croot): find a better way to tag a shape as being a "cross-section line"
-              // Using 'instance of' may be too broad if we end up using LatLonPolyLine as a
-              // general tool for generating a line to filter results using a 'buffer'
-              // Also 'instance of' could be too narrow if we use another shape to draw a cross
-              // section other than LatLonPolyLine
-              // LatLonPolyLine will suffice for now as a differentiator.
+            const { shape, lasso_tool_type = null } = event_obj
+            if (lasso_tool_type === LassoToolSetTypes.kCrossSection) {
+              // if the newly created shape was created as a result of the
+              // CrossSection tool then attach an edit callback to it to
+              // capture any/all edits after creation.
 
               // NOTE: adding an edit event callback directly on a cross-section line shape is one
               // way to do this. An alternative way is to add a global edit event callback for all edited

--- a/example/exampleLineCrossSection.js
+++ b/example/exampleLineCrossSection.js
@@ -209,6 +209,25 @@ function create_charts(
         }
       }
 
+      let is_cross_section_enabled = false
+      pointMapChart.onDrawEvent(
+        LassoGlobalEventConstants.LASSO_TOOL_TYPE_ACTIVATED,
+        event_obj => {
+          if (event_obj.lasso_tool_type === LassoToolSetTypes.kCrossSection) {
+            is_cross_section_enabled = true
+          }
+        }
+      )
+
+      pointMapChart.onDrawEvent(
+        LassoGlobalEventConstants.LASSO_TOOL_TYPE_DEACTIVATED,
+        event_obj => {
+          if (event_obj.lasso_tool_type === LassoToolSetTypes.kCrossSection) {
+            is_cross_section_enabled = false
+          }
+        }
+      )
+
       // setup an event trigger for when a lasso shape is created
       pointMapChart.onDrawEvent(
         LassoGlobalEventConstants.LASSO_SHAPE_CREATE,
@@ -281,6 +300,15 @@ function create_charts(
             // For example, one approach is to set the line to be the bottom
             // edge of the current map view or the bottom edge of the raster
             // volume
+            // Tho you may want to ignore doing this if the shape was deleted
+            // as a result of a new line being drawn. You can check for this
+            // case by checking the "is_cross_section_enabled" variable that's
+            // tied to tool activate/deactivate signals
+            if (!is_cross_section_enabled) {
+              // no cross-section lines are currently drawn or being drawn on
+              // the map, so may want to reset the cross section endpoints to
+              // some default here.
+            }
 
             // turn off the croos-section line-local edit event callback
             // this is not really necessary, but it's good shutdown/cleanup

--- a/src/mixins/ui/lasso-event-constants.js
+++ b/src/mixins/ui/lasso-event-constants.js
@@ -30,13 +30,13 @@ export const LassoGlobalEventConstants = {
   /**
    * triggered when a new shape is being drawn via a lasso tool
    */
-  LASSO_TOOL_CREATE_STARTED: "lasso:tool:create:started",
+  LASSO_TOOL_DRAW_STARTED: "lasso:tool:draw:started",
 
   /**
    * triggered when a new shape draw ends for some reason,
    * either the shape is successfully completed, or cancelled
    */
-  LASSO_TOOL_CREATE_ENDED: "lasso:tool:create:ended",
+  LASSO_TOOL_DRAW_ENDED: "lasso:tool:draw:ended",
 
   /**
    * triggered when a new lasso shape is created

--- a/src/mixins/ui/lasso-event-constants.js
+++ b/src/mixins/ui/lasso-event-constants.js
@@ -28,6 +28,17 @@ export const LassoGlobalEventConstants = {
   LASSO_TOOL_TYPE_DEACTIVATED: "lasso:tool:deactivated",
 
   /**
+   * triggered when a new shape is being drawn via a lasso tool
+   */
+  LASSO_TOOL_CREATE_STARTED: "lasso:tool:create:started",
+
+  /**
+   * triggered when a new shape draw ends for some reason,
+   * either the shape is successfully completed, or cancelled
+   */
+  LASSO_TOOL_CREATE_ENDED: "lasso:tool:create:ended",
+
+  /**
    * triggered when a new lasso shape is created
    */
   LASSO_SHAPE_CREATE: "lasso:shape:create",

--- a/src/mixins/ui/lasso-event-constants.js
+++ b/src/mixins/ui/lasso-event-constants.js
@@ -14,6 +14,20 @@ export const LassoShapeEventConstants = {
 
 export const LassoGlobalEventConstants = {
   /**
+   * triggered when a new lasso tool is activated by pressing its
+   * corresponding button in the lasso tool set ui
+   */
+  LASSO_TOOL_TYPE_ACTIVATED: "lasso:tool:activated",
+
+  /**
+   * triggered when a lasso tool is deactivated. This can happen
+   * when a shape finishes drawing, when a user cancels a drawing
+   * (via esc key) or when the user clicks on its corresponding button
+   * in the lasso tool set ui to manually deactivate it.
+   */
+  LASSO_TOOL_TYPE_DEACTIVATED: "lasso:tool:deactivated",
+
+  /**
    * triggered when a new lasso shape is created
    */
   LASSO_SHAPE_CREATE: "lasso:shape:create",

--- a/src/mixins/ui/lasso-tool-set-types.js
+++ b/src/mixins/ui/lasso-tool-set-types.js
@@ -24,46 +24,49 @@ export default class LassoToolSetTypes {
    * @type {Number}
    */
   // eslint-disable-next-line no-undef
-  static kCircle = new LassoToolSetTypes(1 << 0)
+  static kCircle = new LassoToolSetTypes(1 << 0, "circle")
 
   /**
    * Bitflag identifier for the Polyline draw tool
    * @type {Number}
    */
   // eslint-disable-next-line no-undef
-  static kPolyLine = new LassoToolSetTypes(1 << 1)
+  static kPolyLine = new LassoToolSetTypes(1 << 1, "polyline")
 
   /**
    * Bitflag identifier for the Lasso draw tool
    * @type {Number}
    */
   // eslint-disable-next-line no-undef
-  static kLasso = new LassoToolSetTypes(1 << 2)
+  static kLasso = new LassoToolSetTypes(1 << 2, "lasso")
 
   /**
    * Bitflag identifier for the CrossSection draw tool
    * @type {Number}
    */
   // eslint-disable-next-line no-undef
-  static kCrossSection = new LassoToolSetTypes(1 << 3)
+  static kCrossSection = new LassoToolSetTypes(1 << 3, "cross section")
 
   // eslint-disable-next-line no-undef
   static kAll = new LassoToolSetTypes(
     LassoToolSetTypes.kCircle |
       LassoToolSetTypes.kPolyLine |
       LassoToolSetTypes.kLasso |
-      LassoToolSetTypes.kCrossSection
+      LassoToolSetTypes.kCrossSection,
+    "all"
   )
 
   // eslint-disable-next-line no-undef
   static kStandard = new LassoToolSetTypes(
     LassoToolSetTypes.kCircle |
       LassoToolSetTypes.kPolyLine |
-      LassoToolSetTypes.kLasso
+      LassoToolSetTypes.kLasso,
+    "standard"
   )
 
-  constructor(value) {
+  constructor(value, description = null) {
     this.value = value
+    this.description = description
   }
 
   valueOf() {
@@ -71,6 +74,6 @@ export default class LassoToolSetTypes {
   }
 
   toString() {
-    return `${this.value}`
+    return `${this.description !== null ? this.description : this.value}`
   }
 }

--- a/src/mixins/ui/lasso-tool-ui.js
+++ b/src/mixins/ui/lasso-tool-ui.js
@@ -79,6 +79,10 @@ class ShapeHandler {
     shape.registerEvents(Object.values(LassoShapeEventConstants))
     this.drawEngine.addShape(shape, selectOpts)
     this.drawEngine.moveShapeToTop(shape)
+
+    // now tag the shape to the originating tool, which may be useful
+    // for callback handlers to know
+    shape.lasso_tool_type = this.getLassoToolType()
   }
 
   /**

--- a/src/mixins/ui/lasso-tool-ui.js
+++ b/src/mixins/ui/lasso-tool-ui.js
@@ -59,6 +59,13 @@ class ShapeHandler {
     )
   }
 
+  fireEvent(event_signal, event_obj = {}) {
+    this.drawEngine.fire(event_signal, {
+      ...event_obj,
+      lasso_tool_type: this.getLassoToolType()
+    })
+  }
+
   disableBasemapEvents(options = {}) {
     this.chart.hidePopup(true)
     this.chart.enableInteractions(false, options)
@@ -106,7 +113,7 @@ class ShapeHandler {
       this.chart.addFilterShape(shape)
     }
 
-    this.drawEngine.fire(LassoGlobalEventConstants.LASSO_SHAPE_CREATE, {
+    this.fireEvent(LassoGlobalEventConstants.LASSO_SHAPE_CREATE, {
       shape
     })
 
@@ -161,10 +168,7 @@ class ShapeHandler {
 
       this.active = true
 
-      this.drawEngine.fire(
-        LassoGlobalEventConstants.LASSO_TOOL_TYPE_ACTIVATED,
-        { lasso_tool_type: this.getLassoToolType() }
-      )
+      this.fireEvent(LassoGlobalEventConstants.LASSO_TOOL_TYPE_ACTIVATED)
     }
   }
 
@@ -183,10 +187,7 @@ class ShapeHandler {
 
       this.active = false
 
-      this.drawEngine.fire(
-        LassoGlobalEventConstants.LASSO_TOOL_TYPE_DEACTIVATED,
-        { lasso_tool_type: this.getLassoToolType() }
-      )
+      this.fireEvent(LassoGlobalEventConstants.LASSO_TOOL_TYPE_DEACTIVATED)
     }
   }
 
@@ -282,7 +283,7 @@ class CircleShapeHandler extends ShapeHandler {
   destroy() {
     if (this.activeShape) {
       this.drawEngine.deleteShape(this.activeShape)
-      this.drawEngine.fire(LassoGlobalEventConstants.LASSO_SHAPE_DESTROY, {
+      this.fireEvent(LassoGlobalEventConstants.LASSO_SHAPE_DESTROY, {
         shape: this.activeShape
       })
       this.activeShape = null
@@ -442,7 +443,7 @@ class PolylineShapeHandler extends ShapeHandler {
 
     if (this.polyShape) {
       this.drawEngine.deleteShape(this.polyShape)
-      this.drawEngine.fire(LassoGlobalEventConstants.LASSO_SHAPE_DESTROY, {
+      this.fireEvent(LassoGlobalEventConstants.LASSO_SHAPE_DESTROY, {
         shape: this.polyShape
       })
     }
@@ -713,7 +714,7 @@ class LassoShapeHandler extends ShapeHandler {
 
     if (this.polyShape) {
       this.drawEngine.deleteShape(this.polyShape)
-      this.drawEngine.fire(LassoGlobalEventConstants.LASSO_SHAPE_DESTROY, {
+      this.fireEvent(LassoGlobalEventConstants.LASSO_SHAPE_DESTROY, {
         shape: this.polyShape
       })
       this.polyShape = null
@@ -888,7 +889,7 @@ class CrossSectionLineShapeHandler extends ShapeHandler {
     }
     if (this.lineShape && destroy_line) {
       this.drawEngine.deleteShape(this.lineShape)
-      this.drawEngine.fire(LassoGlobalEventConstants.LASSO_SHAPE_DESTROY, {
+      this.fireEvent(LassoGlobalEventConstants.LASSO_SHAPE_DESTROY, {
         shape: this.lineShape
       })
       this.lineShape = null

--- a/src/mixins/ui/lasso-tool-ui.js
+++ b/src/mixins/ui/lasso-tool-ui.js
@@ -313,7 +313,7 @@ class ShapeHandler {
    * @param {DestroyType} destroy_type Enum describing the context under why the draw stopped
    */
   notifyDrawStop(destroy_type) {
-    this.fireEvent(LassoGlobalEventConstants.LASSO_TOOL_CREATE_ENDED, {
+    this.fireEvent(LassoGlobalEventConstants.LASSO_TOOL_DRAW_ENDED, {
       ended_reason: destroy_type.toString()
     })
   }
@@ -473,7 +473,7 @@ class CircleShapeHandler extends ShapeHandler {
     }
     this.canvas.focus()
     this.addShape(this.activeShape, selectOpts)
-    this.fireEvent(LassoGlobalEventConstants.LASSO_TOOL_CREATE_STARTED)
+    this.fireEvent(LassoGlobalEventConstants.LASSO_TOOL_DRAW_STARTED)
     event.stopImmediatePropagation()
     event.preventDefault()
   }
@@ -704,7 +704,7 @@ class PolylineShapeHandler extends ShapeHandler {
         this.prevVertPos = mousepos
         this.activeIdx = 0
 
-        this.fireEvent(LassoGlobalEventConstants.LASSO_TOOL_CREATE_STARTED)
+        this.fireEvent(LassoGlobalEventConstants.LASSO_TOOL_DRAW_STARTED)
       } else if (!this.lastVert && this.lineShape.numVerts > 1) {
         const verts = this.lineShape.vertsRef
         this.lastVert = new Draw.Point({
@@ -901,7 +901,7 @@ class LassoShapeHandler extends ShapeHandler {
     this.lastPos = this.getRelativeMousePosFromEvent(event)
     this.lastWorldPos = Point2d.create(0, 0)
     this.drawEngine.project(this.lastWorldPos, this.lastPos)
-    this.fireEvent(LassoGlobalEventConstants.LASSO_TOOL_CREATE_STARTED)
+    this.fireEvent(LassoGlobalEventConstants.LASSO_TOOL_DRAW_STARTED)
     event.preventDefault()
   }
 
@@ -1140,12 +1140,12 @@ class CrossSectionLineShapeHandler extends ShapeHandler {
         // before the destroy below to allow users the ability
         // to check whether a shape-destroy signal is the result
         // of a new shape create, if they need that level of control
-        this.fireEvent(LassoGlobalEventConstants.LASSO_TOOL_CREATE_STARTED)
+        this.fireEvent(LassoGlobalEventConstants.LASSO_TOOL_DRAW_STARTED)
 
         // call destroy to clear out any previously existing
         // lines as there can only be one cross-section line
         // at a time.
-        // NOTE: not firing a LASSO_TOOL_CREATE_ENDED event signal here
+        // NOTE: not firing a LASSO_TOOL_DRAW_ENDED event signal here
         this.destroy(DestroyType.kReset)
 
         const args = []

--- a/src/mixins/ui/lasso-tool-ui.js
+++ b/src/mixins/ui/lasso-tool-ui.js
@@ -52,6 +52,13 @@ class ShapeHandler {
       typeof this.chart.useLonLat === "function" && this.chart.useLonLat()
   }
 
+  getLassoToolType() {
+    assert(
+      false,
+      `${ShapeHandler.name}::getLassoToolType() needs to be overridden by derived class`
+    )
+  }
+
   disableBasemapEvents(options = {}) {
     this.chart.hidePopup(true)
     this.chart.enableInteractions(false, options)
@@ -183,6 +190,9 @@ class ShapeHandler {
 
 /* istanbul ignore next */
 class CircleShapeHandler extends ShapeHandler {
+  // eslint-disable-next-line no-undef
+  static lasso_tool_type = LassoToolSetTypes.kCircle
+
   constructor(
     parent,
     drawEngine,
@@ -208,6 +218,10 @@ class CircleShapeHandler extends ShapeHandler {
     }
     this.activeshape = null
     this.timer = null
+  }
+
+  getLassoToolType() {
+    return CircleShapeHandler.lasso_tool_type
   }
 
   deactivateShape() {
@@ -363,6 +377,9 @@ class CircleShapeHandler extends ShapeHandler {
 
 /* istanbul ignore next */
 class PolylineShapeHandler extends ShapeHandler {
+  // eslint-disable-next-line no-undef
+  static lasso_tool_type = LassoToolSetTypes.kPolyLine
+
   constructor(
     parent,
     drawEngine,
@@ -396,6 +413,10 @@ class PolylineShapeHandler extends ShapeHandler {
         this.enableBasemapEvents()
       }
     }, 100)
+  }
+
+  getLassoToolType() {
+    return PolylineShapeHandler.lasso_tool_type
   }
 
   destroy() {
@@ -643,6 +664,9 @@ class PolylineShapeHandler extends ShapeHandler {
 
 /* istanbul ignore next */
 class LassoShapeHandler extends ShapeHandler {
+  // eslint-disable-next-line no-undef
+  static lasso_tool_type = LassoToolSetTypes.kLasso
+
   constructor(
     parent,
     drawEngine,
@@ -665,6 +689,10 @@ class LassoShapeHandler extends ShapeHandler {
     this.polyShape = null
     this.lastPos = null
     this.lastWorldPos = null
+  }
+
+  getLassoToolType() {
+    return LassoShapeHandler.lasso_tool_type
   }
 
   destroy() {
@@ -801,6 +829,9 @@ class LassoShapeHandler extends ShapeHandler {
 }
 
 class CrossSectionLineShapeHandler extends ShapeHandler {
+  // eslint-disable-next-line no-undef
+  static lasso_tool_type = LassoToolSetTypes.kCrossSection
+
   constructor(
     parent,
     drawEngine,
@@ -832,6 +863,10 @@ class CrossSectionLineShapeHandler extends ShapeHandler {
         this.enableBasemapEvents()
       }
     }, 100)
+  }
+
+  getLassoToolType() {
+    return CrossSectionLineShapeHandler.lasso_tool_type
   }
 
   destroy(destroy_line = false) {
@@ -1356,17 +1391,19 @@ export default class LassoButtonGroupController {
       )
     }
 
-    if (lassoToolSetTypes & LassoToolSetTypes.kCircle) {
-      add_handler("circle", CircleShapeHandler)
+    const available_lasso_tools = {
+      circle: CircleShapeHandler,
+      polyline: PolylineShapeHandler,
+      lasso: LassoShapeHandler,
+      CrossSection: CrossSectionLineShapeHandler
     }
-    if (lassoToolSetTypes & LassoToolSetTypes.kPolyLine) {
-      add_handler("polyline", PolylineShapeHandler)
-    }
-    if (lassoToolSetTypes & LassoToolSetTypes.kLasso) {
-      add_handler("lasso", LassoShapeHandler)
-    }
-    if (lassoToolSetTypes & LassoToolSetTypes.kCrossSection) {
-      add_handler("CrossSection", CrossSectionLineShapeHandler)
+
+    for (const [lasso_tool_name, lasso_tool_class] of Object.entries(
+      available_lasso_tools
+    )) {
+      if (lassoToolSetTypes & lasso_tool_class.lasso_tool_type) {
+        add_handler(lasso_tool_name, lasso_tool_class)
+      }
     }
 
     // NOTE: the canvas dom element needs to have a "tabindex" set to have

--- a/src/mixins/ui/lasso-tool-ui.js
+++ b/src/mixins/ui/lasso-tool-ui.js
@@ -930,6 +930,11 @@ class CrossSectionLineShapeHandler extends ShapeHandler {
     if (this.lineShape.numVerts > 1) {
       this.lineShape.setStyle(this.defaultStyle)
       this.setupFinalShape(this.lineShape)
+
+      // tag the line shape as finished useful for
+      // logic elsewhere
+      this.lineShape.is_create_finished = true
+
       // clear out all other shapes using our destroy method
       this.destroy(false)
     } else {
@@ -957,6 +962,11 @@ class CrossSectionLineShapeHandler extends ShapeHandler {
       this.drawEngine.project(mouseworldpos, mousepos)
 
       if (!this.startVert) {
+        // call destroy to clear out any previously existing
+        // lines as there can only be one cross-section line
+        // at a time.
+        this.destroy(true)
+
         const args = []
         let PolyLineClass = null
         if (this.useLonLat) {
@@ -974,6 +984,11 @@ class CrossSectionLineShapeHandler extends ShapeHandler {
           )
         )
         this.lineShape = new PolyLineClass(...args)
+        // add a tag to the lineShape to determine if it is complete
+        // or incomplete (still being created)
+        // This will be set to true in the finishShape() method
+        this.lineShape.is_create_finished = false
+
         this.addShape(this.lineShape)
         this.startVert = new Draw.Point({
           position: mouseworldpos,
@@ -1003,7 +1018,7 @@ class CrossSectionLineShapeHandler extends ShapeHandler {
   }
 
   mousemoveCB(event) {
-    if (this.lineShape) {
+    if (this.lineShape && !this.lineShape.is_create_finished) {
       if (this.lineShape.numVerts === 1) {
         const mousepos = this.getRelativeMousePosFromEvent(event)
         const mouseworldpos = Point2d.create(0, 0)

--- a/src/mixins/ui/lasso-tool-ui.js
+++ b/src/mixins/ui/lasso-tool-ui.js
@@ -160,6 +160,11 @@ class ShapeHandler {
       this.canvas.focus()
 
       this.active = true
+
+      this.drawEngine.fire(
+        LassoGlobalEventConstants.LASSO_TOOL_TYPE_ACTIVATED,
+        { lasso_tool_type: this.getLassoToolType() }
+      )
     }
   }
 
@@ -177,6 +182,11 @@ class ShapeHandler {
       this.canvas.blur()
 
       this.active = false
+
+      this.drawEngine.fire(
+        LassoGlobalEventConstants.LASSO_TOOL_TYPE_DEACTIVATED,
+        { lasso_tool_type: this.getLassoToolType() }
+      )
     }
   }
 


### PR DESCRIPTION
Fixes the bug noted here: https://github.com/heavyai/heavyai-charting/pull/609#issuecomment-1334030150

Also includes an expansion of the event system to include some useful signals to help monitor situations where a cross-section line is deleted when a new cross section line is drawn. This was done as it may be useful to avoid re-drawing the cross section chart in that case and instead wait for the new line draw to complete. The client can check for that case with some new event extensions, namely the:

`LASSO_TOOL_TYPE_ACTIVATED`/`LASSO_TOOL_TYPE_DEACTIVATED` events
or the
`LASSO_TOOL_DRAW_STARTED`/`LASSO_TOOL_DRAW_ENDED` events



# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
