### PR TITLE
[FE-15866][FE-16067] integrate line select tool + prevent error on destroy cross section

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,4 +71,6 @@ export { default as legendContinuous } from "./chart-addons/legend-continuous"
 export { default as legend } from "./chart-addons/legend"
 export { default as legendCont } from "./chart-addons/dc-legend-cont"
 
+export { default as lassoToolSetTypes } from "./mixins/ui/lasso-tool-set-types"
+
 export { default as parseFactsFromCustomSQL } from "./utils/custom-sql-parser"

--- a/src/mixins/raster-draw-mixin.js
+++ b/src/mixins/raster-draw-mixin.js
@@ -673,7 +673,11 @@ export function rasterDrawMixin(chart) {
     return chart
   }
 
-  chart.onDrawEvent = (event, callback) => drawEngine.on(event, callback)
+  chart.onDrawEvent = (event, callback) => {
+    if (drawEngine) {
+      drawEngine.on(event, callback)
+    }
+  }
 
   chart.coordFilter = filter => {
     // noop - for backwards compatibility

--- a/src/mixins/raster-layer-mesh2d-mixin.js
+++ b/src/mixins/raster-layer-mesh2d-mixin.js
@@ -188,17 +188,14 @@ export default function rasterLayerMesh2dMixin(_layer) {
   }
 
   function createCrossfilterDimensionProxy(range) {
-    assert(Array.isArray(range))
-    assert(range.length === 2)
     let range_ = [...range]
     return {
       type: "crossfilter_dimension_proxy",
       getFilter: () => [range_],
       filter: new_range => {
-        assert(Array.isArray(new_range))
-        assert(new_range.length === 2)
         range_ = new_range
-      }
+      },
+      dispose: () => {}
     }
   }
 


### PR DESCRIPTION
Exports constants, guards against some conditions Immerse hits. Asserts for range removed as it is undefined when filterAll is called, which I doubt is new behavior. Added a noop for dispose as cross section seems to only have a dimension proxy.