### PR TITLE
[FE-16149] Add clamp option for contour polygons color scale

### DIFF
--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -619,7 +619,8 @@ export default function rasterLayerPolyMixin(_layer) {
         domain: state.encoding.color.domain,
         range: state.encoding.color.range.map(c =>
           adjustOpacity(c, state.encoding.color.opacity)
-        )
+        ),
+        clamp: Boolean(state.encoding.color.clamp)
       })
     } else {
       const { scale, fillColor: polyFillColor } = getPolygonScale({


### PR DESCRIPTION
The color scale generation needs a bit of investigation/iteration in immerse to match with the TF output, but in the meantime and as a fallback we'll clamp values off the end of the contour polygon fill scale to the ends of the fill scale

Before:
<img width="1727" alt="Screen Shot 2022-12-06 at 5 14 51 PM" src="https://user-images.githubusercontent.com/1031659/206054304-86be88f1-1489-4c5a-b6be-889313326a7f.png">
After:
<img width="1403" alt="Screen Shot 2022-12-06 at 5 14 06 PM" src="https://user-images.githubusercontent.com/1031659/206054287-16088db3-22ea-44f2-be80-4cb0a1c18d3a.png">

With a filter:

Before:
<img width="1136" alt="Screen Shot 2022-12-06 at 5 15 19 PM" src="https://user-images.githubusercontent.com/1031659/206054307-293cea65-992c-4f3c-9ed4-404f6348190c.png">

After:
<img width="1119" alt="Screen Shot 2022-12-06 at 5 16 11 PM" src="https://user-images.githubusercontent.com/1031659/206054308-76a26a7a-30d7-42b7-96e9-427a6fc48680.png">


# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
