### PR TITLE
[FE-16190] Fix SQL to accept custom measures

### DIFF
--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -12,7 +12,6 @@ import { lastFilteredSize, setLastFilteredSize } from "../core/core-async"
 import { parser } from "../utils/utils"
 import * as d3 from "d3"
 import {
-  buildContourSQL,
   buildOptimizedContourSQL,
   getContourBoundingBox,
   getContourMarks,

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -11,7 +11,6 @@ import { parser } from "../utils/utils"
 import { lastFilteredSize } from "../core/core-async"
 import parseFactsFromCustomSQL from "../utils/custom-sql-parser"
 import {
-  buildContourSQL,
   buildOptimizedContourSQL,
   getContourBoundingBox,
   isContourType,

--- a/src/utils/utils-contour.js
+++ b/src/utils/utils-contour.js
@@ -90,7 +90,7 @@ export const buildOptimizedContourSQL = ({
   const groupedQuery = `select
     cast((${lonFieldParsed}) / ${multiplier} as int) as lon_int,
     cast((${latFieldParsed}) / ${multiplier} as int) as lat_int,
-    avg(${contour_value_field.value}) as ${contourValueName}
+    avg(${contour_value_field}) as ${contourValueName}
   from
     ${table}
     ${rasterSelectFilter}
@@ -170,13 +170,12 @@ export const buildContourSQL = ({
     ? `where ${validRasterTransforms.map(ft => ft.expr).join(" AND ")}`
     : ""
   const rasterSelect = is_geo_point_type
-    ? `select ST_X(${lon_field}), ST_Y(${lat_field}),  ${contour_value_field.value} from ${table} ${rasterSelectFilter}`
-    : `select ${lon_field}, ${lat_field},  ${contour_value_field.value} from ${table} ${rasterSelectFilter}`
+    ? `select ST_X(${lon_field}), ST_Y(${lat_field}),  ${contour_value_field} from ${table} ${rasterSelectFilter}`
+    : `select ${lon_field}, ${lat_field},  ${contour_value_field} from ${table} ${rasterSelectFilter}`
 
   // Transform params object into 'param_name' => 'param_value', ... for sql query
   const contourParamsSQL = buildParamsSQL(contourParams)
 
-  // TODO: Use geocol here
   const geometryColumn = isPolygons ? "contour_polygons" : "contour_lines"
   const contourLineCase = `CASE mod(cast(contour_values as int), ${majorInterval}) WHEN 0 THEN 1 ELSE 0 END as ${isMajorFieldName} `
   const contourTableFunction = isPolygons


### PR DESCRIPTION
SQL generation code was written with the assumption that the field passed in was a field name, but can be an expression. This changes to use a const for output field alias. 

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
