### PR TITLE
[FE-16237] Set new prop to avoid filtering on clicked poly for contour

### DIFF
--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -718,6 +718,12 @@ export default function rasterLayerPolyMixin(_layer) {
     return false
   }
 
+  let _onClickFiltering = true
+
+  _layer.setOnClickFiltering = function(value) {
+    _onClickFiltering = value
+  }
+
   _layer.viewBoxDim = createRasterLayerGetterSetter(_layer, null)
   _layer.xDim = createRasterLayerGetterSetter(_layer, null)
   _layer.yDim = createRasterLayerGetterSetter(_layer, null)
@@ -902,8 +908,9 @@ export default function rasterLayerPolyMixin(_layer) {
     if (!data) {
       return
     } else if (
-      _layer.getState().currentLayer === "master" &&
-      chartHasMoreThanOnePolyLayers(chart)
+      (_layer.getState().currentLayer === "master" &&
+        chartHasMoreThanOnePolyLayers(chart)) ||
+      !_onClickFiltering
     ) {
       // don't filter from Master, FE-8685
       return


### PR DESCRIPTION
Previously polygon layer had a default `onClick` function which filters by the poly selected.  This is not wanted for contour (especially since it interferes with the cross-section line tool), so adding a new settable property to the layer which can be used to bypass this function.

This fixes an issue with the line tool in contour where the `onClick` handler for this layer would fire when a user clicks to start or end a line, and filter out all the results from the data set.
