### PR TITLE
[FE-16290] Contour multilayer support

### DIFF
--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -534,7 +534,7 @@ export function toLegendState(states = [], chart, useMap) {
   }
 }
 
-function isNullLegend(domain) {
+function isNullLegend(domain = []) {
   // only return true if there is more than one "NULL" value
-  return domain.reduce((cnt, d) => (d === "NULL" ? cnt + 1 : cnt), 0) > 1
+  return Array.isArray(domain) && domain?.filter(d => d === "NULL")?.length > 1
 }

--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -417,7 +417,7 @@ export default function rasterLayerLineMixin(_layer) {
 
     let scales
     if (isContourType(state)) {
-      scales = getContourScales(state.encoding)
+      scales = getContourScales(layerName, state.encoding)
     } else {
       scales = getScales(
         state.encoding,

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -614,7 +614,7 @@ export default function rasterLayerPolyMixin(_layer) {
     let fillColor = "#AAAAAA"
     if (isContourType(state)) {
       scales.push({
-        name: "contour_fill",
+        name: `${layerName}_contour_fill`,
         type: state.encoding.color.type,
         domain: state.encoding.color.domain,
         range: state.encoding.color.range.map(c =>
@@ -651,7 +651,7 @@ export default function rasterLayerPolyMixin(_layer) {
           },
           fillColor: {
             field: "contour_values",
-            scale: "contour_fill"
+            scale: `${layerName}_contour_fill`
           },
           strokeColor: "white",
           strokeWidth: 0,

--- a/src/utils/utils-contour.js
+++ b/src/utils/utils-contour.js
@@ -209,7 +209,7 @@ export const getContourMarks = (layerName, state) => [
         field: state.encoding.color.field
       },
       strokeWidth: {
-        scale:  `${layerName}_${CONTOUR_STROKE_WIDTH_SCALE}`,
+        scale: `${layerName}_${CONTOUR_STROKE_WIDTH_SCALE}`,
         field: state.encoding.strokeWidth.field
       },
       lineJoin: state.mark.lineJoin
@@ -217,7 +217,10 @@ export const getContourMarks = (layerName, state) => [
   }
 ]
 
-export const getContourScales = (layerName, { strokeWidth, opacity, color }) => {
+export const getContourScales = (
+  layerName,
+  { strokeWidth, opacity, color }
+) => {
   const [minorOpacity, majorOpacity] = opacity.scale.range
   const [minorColor, majorColor] = color.scale.range
 

--- a/src/utils/utils-contour.js
+++ b/src/utils/utils-contour.js
@@ -205,11 +205,11 @@ export const getContourMarks = (layerName, state) => [
         field: "y"
       },
       strokeColor: {
-        scale: CONTOUR_COLOR_SCALE,
+        scale: `${layerName}_${CONTOUR_COLOR_SCALE}`,
         field: state.encoding.color.field
       },
       strokeWidth: {
-        scale: CONTOUR_STROKE_WIDTH_SCALE,
+        scale:  `${layerName}_${CONTOUR_STROKE_WIDTH_SCALE}`,
         field: state.encoding.strokeWidth.field
       },
       lineJoin: state.mark.lineJoin
@@ -217,19 +217,19 @@ export const getContourMarks = (layerName, state) => [
   }
 ]
 
-export const getContourScales = ({ strokeWidth, opacity, color }) => {
+export const getContourScales = (layerName, { strokeWidth, opacity, color }) => {
   const [minorOpacity, majorOpacity] = opacity.scale.range
   const [minorColor, majorColor] = color.scale.range
 
   return [
     {
-      name: CONTOUR_STROKE_WIDTH_SCALE,
+      name: `${layerName}_${CONTOUR_STROKE_WIDTH_SCALE}`,
       type: "ordinal",
       domain: strokeWidth.scale.domain,
       range: strokeWidth.scale.range
     },
     {
-      name: CONTOUR_COLOR_SCALE,
+      name: `${layerName}_${CONTOUR_COLOR_SCALE}`,
       type: "ordinal",
       domain: color.scale.domain,
       range: [


### PR DESCRIPTION
In order to have multiple contour charts in one layer, we need to name the scales on a per layer basis. This includes the layer name for each scale so that we can have multiple color, width scales in the same vega spec. 

This also refactors a small bit of legend code to make sure the domain is an array, and make the check a little simpler