### PR TITLE
[FE-16243] Create new method to setup x and y dims just for contour

### DIFF
--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -473,8 +473,14 @@ export default function rasterLayerLineMixin(_layer) {
   }
 
   _layer.viewBoxDim = createRasterLayerGetterSetter(_layer, null)
-  _layer.xDim = createRasterLayerGetterSetter(_layer, null)
-  _layer.yDim = createRasterLayerGetterSetter(_layer, null)
+
+  // linemap bbox filter gets broken if these are set for its layer, but contour
+  // needs them to be set for its bbox filter; therefore wrap in a method that
+  // can be called from contour setup prior to setting vals
+  _layer.setContourXYDims = function() {
+    _layer.xDim = createRasterLayerGetterSetter(_layer, null)
+    _layer.yDim = createRasterLayerGetterSetter(_layer, null)
+  }
 
   createVegaAttrMixin(_layer, "size", 3, 1, true)
 

--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -477,7 +477,7 @@ export default function rasterLayerLineMixin(_layer) {
   // linemap bbox filter gets broken if these are set for its layer, but contour
   // needs them to be set for its bbox filter; therefore wrap in a method that
   // can be called from contour setup prior to setting vals
-  _layer.setContourXYDims = function() {
+  _layer.initializeXYDims = function() {
     _layer.xDim = createRasterLayerGetterSetter(_layer, null)
     _layer.yDim = createRasterLayerGetterSetter(_layer, null)
   }


### PR DESCRIPTION
Creating the `xDim` and `yDim` getter/setters by default fixed the contour bbox filter issue, but broke linemap (assuming there is some check later down the line for these that sends it down a different codepath).  Thus, simple solution is to wrap the creation of these properties in a method that can be called from contour, to allow them to be accessible to contour but not be automatically set-up for linemap. 
