### PR TITLE
[FE-16795] [FE-16796] Add second y-axis, ensure y-axes alignment

### DIFF
--- a/dist/charting.css
+++ b/dist/charting.css
@@ -631,7 +631,7 @@ body {
       fill-opacity: #868686; }
   .dc-chart text.deselected-label {
     fill: #868686 !important; }
-  .dc-chart div.x-axis-label, .dc-chart div.y-axis-label, .dc-chart div.axis-label-edit {
+  .dc-chart div.x-axis-label, .dc-chart div.y-axis-label, .dc-chart div.y2-axis-label, .dc-chart div.axis-label-edit {
     position: absolute;
     font-size: 13px !important;
     color: #868686;
@@ -639,11 +639,11 @@ body {
     pointer-events: none;
     height: 18px;
     max-width: 100%; }
-  .dc-chart div.y-axis-label, .dc-chart div.axis-label-edit.type-y {
+  .dc-chart div.y-axis-label, .dc-chart div.axis-label-edit.type-y, .dc-chart div.y2-axis-label, .dc-chart div.axis-label-edit.type-y2 {
     transform-origin: 50% 0;
     transform: translateX(-50%) rotate(270deg);
     left: 4px; }
-    .dc-chart div.y-axis-label input, .dc-chart div.axis-label-edit.type-y input {
+    .dc-chart div.y-axis-label input, .dc-chart div.axis-label-edit.type-y input, .dc-chart div.y2-axis-label input, .dc-chart div.axis-label-edit.type-y2 input {
       cursor: vertical-text;
       top: -1px; }
   .dc-chart div.x-axis-label, .dc-chart div.axis-label-edit.type-x {
@@ -1832,6 +1832,10 @@ body {
   .axis-lock.type-y .axis-input {
     transform: translate(calc(-100% - 8px), -50%); }
     .axis-lock.type-y .axis-input input {
+      text-align: right; }
+  .axis-lock.type-y2 .axis-input {
+    transform: translate(calc(-100% - 8px), -50%); }
+    .axis-lock.type-y2 .axis-input input {
       text-align: right; }
   .axis-lock .hit-box {
     position: absolute; }

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -457,15 +457,6 @@ body {
         }
     }
 
-    /*div.y2-axis-label, div.axis-label-edit.type-y2 {
-        transform-origin: 50% 0;
-        transform:translateX(-50%) rotate(90deg) ;
-        input {
-            cursor: vertical-text;
-            top: -1px;
-        }
-    }*/
-
 
     div.x-axis-label, div.axis-label-edit.type-x {
         transform: translateX(-50%);

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -457,6 +457,15 @@ body {
         }
     }
 
+    /*div.y2-axis-label, div.axis-label-edit.type-y2 {
+        transform-origin: 50% 0;
+        transform:translateX(-50%) rotate(90deg) ;
+        input {
+            cursor: vertical-text;
+            top: -1px;
+        }
+    }*/
+
 
     div.x-axis-label, div.axis-label-edit.type-x {
         transform: translateX(-50%);

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -437,7 +437,7 @@ body {
         fill: $gray5 !important;
     }
 
-    div.x-axis-label, div.y-axis-label, div.axis-label-edit {
+    div.x-axis-label, div.y-axis-label, div.y2-axis-label, div.axis-label-edit {
         position: absolute;
         font-size: 13px !important;
         color: $text-gray;
@@ -447,7 +447,7 @@ body {
         max-width: 100%;
     }
 
-    div.y-axis-label, div.axis-label-edit.type-y {
+    div.y-axis-label, div.axis-label-edit.type-y, div.y2-axis-label, div.axis-label-edit.type-y2 {
         transform-origin: 50% 0;
         transform:translateX(-50%) rotate(270deg) ;
         left: 4px;
@@ -2305,6 +2305,13 @@ body {
     }
 
     &.type-y .axis-input {
+        transform: translate(calc(-100% - 8px), -50%);
+        input {
+            text-align: right;
+        }
+    }
+
+    &.type-y2 .axis-input {
         transform: translate(calc(-100% - 8px), -50%);
         input {
             text-align: right;

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -294,7 +294,7 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
   }
 
   _chart.getAllLayerTypes = function() {
-    return _layers.map(layer => layer?.layerType())
+    return _chart.getAllLayers().map(l => l?.layerType())
   }
 
   _chart.xRangeFilter = function(filter) {

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -78,8 +78,10 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
 
   let _x = null
   let _y = null
+  let _y2 = null
   const _xScaleName = "x"
   const _yScaleName = "y"
+  const _y2ScaleName = "y2"
 
   let _xLatLngBnds = null
   let _yLatLngBnds = null
@@ -142,6 +144,14 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
       return _y
     }
     _y = _
+    return _chart
+  }
+
+  _chart.y2 = function(_) {
+    if (!arguments.length) {
+      return _y2
+    }
+    _y2 = _
     return _chart
   }
 
@@ -484,13 +494,18 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
     return _yScaleName
   }
 
+  _chart._getY2ScaleName = function() {
+    return _y2ScaleName
+  }
+
   _chart._updateXAndYScales = function(renderBounds) {
     // renderBounds should be in this order - top left, top-right, bottom-right, bottom-left
     const useRenderBounds =
       renderBounds &&
       renderBounds.length === 4 &&
       renderBounds[0] instanceof Array &&
-      renderBounds[0].length === 2
+      renderBounds[0].length === 2 &&
+      !_chart.useTwoYAxes()
 
     if (_x === null) {
       _x = d3.scale.linear()
@@ -498,6 +513,10 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
 
     if (_y === null) {
       _y = d3.scale.linear()
+    }
+
+    if (_y2 === null && _chart.useTwoYAxes()) {
+      _y2 = d3.scale.linear()
     }
 
     // if _chart.useLonLat() is not true, the chart bounds have already been projected into mercator space
@@ -525,8 +544,107 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
         _x.domain([renderBounds[0][0], renderBounds[1][0]])
         _y.domain([renderBounds[2][1], renderBounds[0][1]])
       }
+    } else if (_chart.useTwoYAxes()) {
+      const layers = _chart.getLayers()
+      const xRanges = []
+      const yRanges = []
+      const y2Ranges = []
+
+      for (const layer of layers) {
+        let xDim = layer.xDim(),
+          yDim = layer.yDim()
+        if (xDim) {
+          var range = xDim.getFilter()
+          if (range !== null) {
+            // value coming back is an unnecessarily nested array - [[0, 1]]
+            if (range[0] && Array.isArray(range[0])) {
+              xRanges.push(range.flatMap(r => r))
+            } else {
+              xRanges.push(range)
+            }
+          }
+        }
+        if (yDim) {
+          var range = yDim.getFilter()
+          if (range !== null) {
+            // value coming back is an unnecessarily nested array - [[0, 1]]
+            if (range[0] && Array.isArray(range[0])) {
+              range = range.flatMap(r => r)
+            }
+            layer.layerType() === "crossSectionTerrain"
+              ? y2Ranges.push(range)
+              : yRanges.push(range)
+          }
+        }
+      }
+
+      if (xRanges.length) {
+        const xRange = xRanges.reduce(
+          (prevVal, currVal) => [
+            Math.min(prevVal[0], currVal[0]),
+            Math.max(prevVal[1], currVal[1])
+          ],
+          [Number.MAX_VALUE, -Number.MAX_VALUE]
+        )
+
+        if (typeof _chart.useLonLat === "function" && _chart.useLonLat()) {
+          _x.domain([
+            _chart.conv4326To900913X(xRange[0]),
+            _chart.conv4326To900913X(xRange[1])
+          ])
+        } else {
+          _x.domain(xRange)
+        }
+      } else {
+        _x.domain([0.001, 0.999])
+      }
+
+      if (yRanges.length) {
+        const yRange = yRanges.reduce(
+          (prevVal, currVal) => [
+            Math.min(prevVal[0], currVal[0]),
+            Math.max(prevVal[1], currVal[1])
+          ],
+          [Number.MAX_VALUE, -Number.MAX_VALUE]
+        )
+
+        // This might be pointless
+        if (typeof _chart.useLonLat === "function" && _chart.useLonLat()) {
+          _y.domain([
+            _chart.conv4326To900913X(yRange[0]),
+            _chart.conv4326To900913X(yRange[1])
+          ])
+        } else {
+          _y.domain(yRange)
+        }
+      } else {
+        _y.domain([0.001, 0.999])
+      }
+
+      if (y2Ranges.length) {
+        const y2Range = y2Ranges.reduce(
+          (prevVal, currVal) => [
+            Math.min(prevVal[0], currVal[0]),
+            Math.max(prevVal[1], currVal[1])
+          ],
+          [Number.MAX_VALUE, -Number.MAX_VALUE]
+        )
+
+        // This might be pointless
+        if (typeof _chart.useLonLat === "function" && _chart.useLonLat()) {
+          _y2.domain([
+            _chart.conv4326To900913X(y2Range[0]),
+            _chart.conv4326To900913X(y2Range[1])
+          ])
+        } else {
+          _y2.domain(y2Range)
+        }
+      } else if (y2Ranges.length === 1) {
+        _y2.domain(y2Ranges[0])
+      } else {
+        _y2.domain([0.001, 0.999])
+      }
     } else {
-      // TODO(C): THIS IS WHERE THIS IS HAPPENING
       const layers = getLayers()
       const xRanges = []
       const yRanges = []
@@ -939,6 +1057,7 @@ function genLayeredVega(chart) {
       nullValue: -100
     }
   ]
+  // TODO(matzy): This can probably be cleaned up now that chart.y2() exists
   checkMultiYScaleLayers(chart, scales)
 
   // NOTE(adb): When geo types are enabled, vega spatial projections are applied and the scales for the x and y properties are not being used. However, we still need the legacy scaling terms to properly size poly popups on hover, which is why _xLatLngBnds, etc are separate scales

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -554,7 +554,7 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
         let xDim = layer.xDim(),
           yDim = layer.yDim()
         if (xDim) {
-          let range = xDim.getFilter()
+          const range = xDim.getFilter()
           if (range !== null) {
             // value coming back is an unnecessarily nested array - [[0, 1]]
             if (range[0] && Array.isArray(range[0])) {
@@ -654,13 +654,13 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
           yDim = layer.yDim(),
           viewBoxDim = layer.viewBoxDim()
         if (xDim) {
-          let range = xDim.getFilter()
+          const range = xDim.getFilter()
           if (range !== null) {
             xRanges.push(range)
           }
         }
         if (yDim) {
-          let range = yDim.getFilter()
+          const range = yDim.getFilter()
           if (range !== null) {
             yRanges.push(range)
           }

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -526,6 +526,7 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
         _y.domain([renderBounds[2][1], renderBounds[0][1]])
       }
     } else {
+      // TODO(C): THIS IS WHERE THIS IS HAPPENING
       const layers = getLayers()
       const xRanges = []
       const yRanges = []

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -880,7 +880,7 @@ function valuesOb(obj) {
 
 function checkMultiYScaleLayers(chart, scales) {
   const layers = chart.getAllLayers()
-  const layerTypes = layers.map(l => l?.layerType())
+  const layerTypes = chart.getAllLayerTypes()
   const terrainLayer = layers.filter(
     l => l?.layerType() === "crossSectionTerrain"
   )

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -244,6 +244,14 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
       _layerNames[layerName] = layer
     }
 
+    const currentLayerTypes = _chart.getAllLayerTypes()
+    if (
+      currentLayerTypes.includes("mesh2d") &&
+      currentLayerTypes.includes("crossSectionTerrain")
+    ) {
+      _chart.useTwoYAxes(true)
+    }
+
     return _chart
   }
 
@@ -283,6 +291,10 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
 
   _chart.getLayerNames = function() {
     return _layers
+  }
+
+  _chart.getAllLayerTypes = function() {
+    return _layers.map(layer => layer?.layerType())
   }
 
   _chart.xRangeFilter = function(filter) {

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -554,7 +554,7 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
         let xDim = layer.xDim(),
           yDim = layer.yDim()
         if (xDim) {
-          var range = xDim.getFilter()
+          let range = xDim.getFilter()
           if (range !== null) {
             // value coming back is an unnecessarily nested array - [[0, 1]]
             if (range[0] && Array.isArray(range[0])) {
@@ -565,7 +565,7 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
           }
         }
         if (yDim) {
-          var range = yDim.getFilter()
+          let range = yDim.getFilter()
           if (range !== null) {
             // value coming back is an unnecessarily nested array - [[0, 1]]
             if (range[0] && Array.isArray(range[0])) {
@@ -654,13 +654,13 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
           yDim = layer.yDim(),
           viewBoxDim = layer.viewBoxDim()
         if (xDim) {
-          var range = xDim.getFilter()
+          let range = xDim.getFilter()
           if (range !== null) {
             xRanges.push(range)
           }
         }
         if (yDim) {
-          var range = yDim.getFilter()
+          let range = yDim.getFilter()
           if (range !== null) {
             yRanges.push(range)
           }

--- a/src/mixins/base-mixin.js
+++ b/src/mixins/base-mixin.js
@@ -1800,6 +1800,7 @@ export default function baseMixin(_chart) {
       "group",
       "xAxisLabel",
       "yAxisLabel",
+      "y2AxisLabel",
       "stack",
       "title",
       "point",

--- a/src/mixins/coordinate-grid-raster-mixin.js
+++ b/src/mixins/coordinate-grid-raster-mixin.js
@@ -1485,7 +1485,7 @@ axis in dc.js is simply an instance of a [d3 axis
     prepareXAxis(_chart.g(), _chart.x(), render, transitionDuration)
     _chart._prepareYAxis(_chart.g(), _chart.y(), transitionDuration)
     if (_chart.useTwoYAxes()) {
-      _chart._prepareY2Axis(_chart.g(), _chart.y(), transitionDuration)
+      _chart._prepareY2Axis(_chart.g(), _chart.y2(), transitionDuration)
     }
 
     if (_chart.elasticX() || _resizing || render) {

--- a/src/mixins/coordinate-grid-raster-mixin.js
+++ b/src/mixins/coordinate-grid-raster-mixin.js
@@ -1073,7 +1073,6 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
 
     if (yLabel.empty()) {
       yLabel = root.append("div")
-        // .attr("class", axisClass + "-axis-label")
         .attr("class", `${axisClass}-axis-label`)
     }
 

--- a/src/mixins/coordinate-grid-raster-mixin.js
+++ b/src/mixins/coordinate-grid-raster-mixin.js
@@ -693,6 +693,10 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
       .attr("width", width * pixelRatio)
       .attr("height", height * pixelRatio)
 
+    if (_chart.useTwoYAxes()) {
+      _chartBody.style("right", right + "px")
+    }
+
     _parent.style("width", (width + (right + left)) + "px")
       .style("height", (height + (top + bottom)) + "px")
       .attr("width", (width + (right + left)) * pixelRatio)
@@ -1066,6 +1070,7 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
 
     if (yLabel.empty()) {
       yLabel = root.append("div")
+        // .attr("class", axisClass + "-axis-label")
         .attr("class", "y-axis-label")
     }
 
@@ -1102,6 +1107,14 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
     const labelPosition = _useRightYAxis ? (_chart.width() - _yAxisLabelPadding) : _yAxisLabelPadding
     const rotation = _useRightYAxis ? 90 : -90
     _chart.renderYAxisLabel("y", _chart.yAxisLabel(), rotation, labelPosition)
+  }
+
+  _chart.renderY2Axis = function (g, transitionDuration) {
+    const axisPosition = _chart.width() - _chart.margins().right
+    _chart.renderYAxisAt("y2", _y2Axis, axisPosition, transitionDuration)
+    const labelPosition = (_chart.width() + _yAxisLabelPadding)
+    const rotation = 90
+    _chart.renderYAxisLabel("y2", _chart.yAxisLabel(), rotation, labelPosition)
   }
 
   _chart._renderHorizontalGridLinesForAxis = function (g, scale, axis, transitionDuration) {
@@ -1430,8 +1443,9 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
       _chart.renderYAxis(_chart.g(), transitionDuration)
 
       if (_chart.useTwoYAxes()) {
+        _chart.margins().right = 60
         _chart.useRightYAxis(true)
-        _chart.renderYAxis(_chart.g(), transitionDuration)
+        _chart.renderY2Axis(_chart.g(), transitionDuration)
         // TODO(C): is this needed?
         _chart.useRightYAxis(false)
       }

--- a/src/mixins/coordinate-grid-raster-mixin.js
+++ b/src/mixins/coordinate-grid-raster-mixin.js
@@ -1117,7 +1117,6 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
   }
 
   _chart.renderY2Axis = function (g, transitionDuration) {
-    console.log("y2 axis position", _chart.width() - _chart.margins().right)
     const axisPosition = _chart.width() - _chart.margins().right
     _chart.renderYAxisAt("y2", _y2Axis, axisPosition, transitionDuration)
     const labelPosition = (_chart.width() + _yAxisLabelPadding)

--- a/src/mixins/coordinate-grid-raster-mixin.js
+++ b/src/mixins/coordinate-grid-raster-mixin.js
@@ -1050,9 +1050,7 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
 
     _y2Axis.ticks(_chart.effectiveHeight() / _y2Axis.scale().ticks().length < 16 ? Math.ceil(_chart.effectiveHeight() / 16) : 10)
 
-    if (_useRightYAxis) {
-      _y2Axis.orient("right")
-    }
+    _y2Axis.orient("right")
 
     setYAxisFormat()
 

--- a/src/mixins/coordinate-grid-raster-mixin.js
+++ b/src/mixins/coordinate-grid-raster-mixin.js
@@ -1420,7 +1420,7 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
 
     prepareXAxis(_chart.g(), _chart.x(), render, transitionDuration)
     _chart._prepareYAxis(_chart.g(), _chart.y(), transitionDuration)
-    if (chart.useTwoYAxes()) {
+    if (_chart.useTwoYAxes()) {
       _chart._prepareY2Axis(_chart.g(), _chart.y(), transitionDuration)
     }
 

--- a/src/mixins/coordinate-grid-raster-mixin.js
+++ b/src/mixins/coordinate-grid-raster-mixin.js
@@ -134,6 +134,9 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
   let _yAxisLabelPadding = 0
 
   let _y2Axis = d3.svg.axis().orient("right")
+  let _y2AxisPadding = 0
+  let _y2AxisLabel
+  let _y2AxisLabelPadding = 0
 
   let _renderHorizontalGridLine = false
   let _renderVerticalGridLine = false
@@ -1059,24 +1062,28 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
     setYAxisFormat()
 
     _chart._renderHorizontalGridLinesForAxis(g, y, _y2Axis, transitionDuration)
-    _chart.prepareLabelEdit("y")
+    _chart.prepareLabelEdit("y2")
     _chart.prepareLockAxis("y")
   }
 
   _chart.renderYAxisLabel = function (axisClass, text, rotation, labelXPosition) {
     const root = _chart.root()
 
-    let yLabel = root.selectAll(".y-axis-label")
+    let yLabel = root.selectAll(`.${axisClass}-axis-label`)
 
     if (yLabel.empty()) {
       yLabel = root.append("div")
         // .attr("class", axisClass + "-axis-label")
-        .attr("class", "y-axis-label")
+        .attr("class", `${axisClass}-axis-label`)
     }
 
     if (text !== "") {
       // TODO(croot): should add the rotation and labelXPosition here
       // As of now (09/02/2016) the chart.css is breaking this.
+
+      if (axisClass === "y2") {
+        yLabel.style("right", 0)
+      }
 
       yLabel
         .style("top", (_chart.effectiveHeight() / 2 + _chart.margins().top) + "px")
@@ -1110,11 +1117,12 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
   }
 
   _chart.renderY2Axis = function (g, transitionDuration) {
+    console.log("y2 axis position", _chart.width() - _chart.margins().right)
     const axisPosition = _chart.width() - _chart.margins().right
     _chart.renderYAxisAt("y2", _y2Axis, axisPosition, transitionDuration)
     const labelPosition = (_chart.width() + _yAxisLabelPadding)
     const rotation = 90
-    _chart.renderYAxisLabel("y2", _chart.yAxisLabel(), rotation, labelPosition)
+    _chart.renderYAxisLabel("y2", _chart.y2AxisLabel(), rotation, labelPosition)
   }
 
   _chart._renderHorizontalGridLinesForAxis = function (g, scale, axis, transitionDuration) {
@@ -1190,8 +1198,32 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
   }
 
   /**
+   * Set or get the y2 axis label. If setting the label, you may optionally include additional padding
+   * to the margin to make room for the label. By default the padded is set to 12 to accomodate the
+   * text height.
+   * @name y2AxisLabel
+   * @memberof dc.coordinateGridRasterMixin
+   * @instance
+   * @param {String} [labelText]
+   * @param {Number} [padding=12]
+   * @return {String}
+   * @return {dc.coordinateGridRasterMixin}
+   */
+  _chart.y2AxisLabel = function (labelText, padding) {
+    if (!arguments.length) {
+      return _y2AxisLabel
+    }
+    _y2AxisLabel = labelText
+    _chart.margins().left -= _y2AxisLabelPadding
+    _y2AxisLabelPadding = (padding === undefined) ? DEFAULT_AXIS_LABEL_PADDING : padding
+    _chart.margins().left += _y2AxisLabelPadding
+    return _chart
+  }
+
+  /**
    * Set or get the y axis used by the coordinate grid chart instance. This function is most useful
-   * when y axis customization is required. The y axis in dc.js is simply an instance of a [d3 axis
+   * when y axis customization is required. The y   let _yAxisLabelPadding = 0
+axis in dc.js is simply an instance of a [d3 axis
    * object](https://github.com/mbostock/d3/wiki/SVG-Axes#wiki-_axis); therefore it supports any
    * valid d3 axis manipulation. **Caution**: The y axis is usually generated internally by dc
    * resetting it may cause unexpected results.
@@ -1287,6 +1319,28 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
       return _yAxisPadding
     }
     _yAxisPadding = padding
+    return _chart
+  }
+
+  /**
+   * Set or get y2 axis padding for the elastic y2 axis. The padding will be added to the top of the y2
+   * axis if elasticY is turned on; otherwise it is ignored.
+   *
+   * padding can be an integer or percentage in string (e.g. "10%"). Padding can be applied to
+   * number or date axes. When padding a date axis, an integer represents number of days being padded
+   * and a percentage string will be treated the same as an integer.
+   * @name y2AxisPadding
+   * @memberof dc.coordinateGridRasterMixin
+   * @instance
+   * @param {Number|String} [padding=0]
+   * @return {Number}
+   * @return {dc.coordinateGridRasterMixin}
+   */
+  _chart.y2AxisPadding = function (padding) {
+    if (!arguments.length) {
+      return _y2AxisPadding
+    }
+    _y2AxisPadding = padding
     return _chart
   }
 

--- a/src/mixins/coordinate-grid-raster-mixin.js
+++ b/src/mixins/coordinate-grid-raster-mixin.js
@@ -1444,10 +1444,7 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
 
       if (_chart.useTwoYAxes()) {
         _chart.margins().right = 60
-        _chart.useRightYAxis(true)
         _chart.renderY2Axis(_chart.g(), transitionDuration)
-        // TODO(C): is this needed?
-        _chart.useRightYAxis(false)
       }
     }
 

--- a/src/mixins/label-mixin.js
+++ b/src/mixins/label-mixin.js
@@ -121,8 +121,15 @@ export default function labelMixin(chart) {
       chart.legend().legendType() === "quantitative"
 
     const iconPosition = {
-      left: type === "y" ? "" : `${getXaxisLeftPosition(hasLegend)}px`,
-      top: type === "y" ? `${getYaxisTopPosition()}px` : ""
+      left:
+        type === "y" || type === "y2"
+          ? ""
+          : `${getXaxisLeftPosition(hasLegend)}px`,
+      top: type === "y" || type === "y2" ? `${getYaxisTopPosition()}px` : ""
+    }
+
+    if (type === "y2") {
+      iconPosition.left = `${getXaxisLeftPosition(hasLegend) * 2}px`
     }
 
     chart
@@ -132,7 +139,7 @@ export default function labelMixin(chart) {
 
     chart
       .root()
-      .selectAll(".y-axis-label, .x-axis-label")
+      .selectAll(".y-axis-label, .x-axis-label, .y2-axis-label")
       .style("display", "none")
 
     const editorWrapper = chart

--- a/src/mixins/label-mixin.js
+++ b/src/mixins/label-mixin.js
@@ -121,11 +121,10 @@ export default function labelMixin(chart) {
       chart.legend().legendType() === "quantitative"
 
     const iconPosition = {
-      left:
-        type === "y" || type === "y2"
-          ? ""
-          : `${getXaxisLeftPosition(hasLegend)}px`,
-      top: type === "y" || type === "y2" ? `${getYaxisTopPosition()}px` : ""
+      left: ["y", "y2"].includes(type)
+        ? ""
+        : `${getXaxisLeftPosition(hasLegend)}px`,
+      top: ["y", "y2"].includes(type) ? `${getYaxisTopPosition()}px` : ""
     }
 
     if (type === "y2") {

--- a/src/mixins/label-mixin.js
+++ b/src/mixins/label-mixin.js
@@ -129,7 +129,7 @@ export default function labelMixin(chart) {
     }
 
     if (type === "y2") {
-      iconPosition.left = `${getXaxisLeftPosition(hasLegend) * 2}px`
+      iconPosition.left = `${chart.width() - chart.margins().right / 2.5}px`
     }
 
     chart

--- a/src/mixins/scatter-mixin.js
+++ b/src/mixins/scatter-mixin.js
@@ -101,6 +101,7 @@ export default function scatterMixin(_chart, _mapboxgl, mixinDraw = true) {
   }
 
   _chart.getDataRenderBounds = function() {
+    // TODO(C): THIS COULD ALSO BE WHERE THIS IS HAPPENING
     const dimRangeData = initializeXYDimsAndRanges(_chart)
     const xRanges = dimRangeData.xRanges
     const yRanges = dimRangeData.yRanges

--- a/src/mixins/scatter-mixin.js
+++ b/src/mixins/scatter-mixin.js
@@ -113,7 +113,6 @@ export default function scatterMixin(_chart, _mapboxgl, mixinDraw = true) {
   }
 
   _chart.getDataRenderBounds = function() {
-    // TODO(C): THIS COULD ALSO BE WHERE THIS IS HAPPENING
     const dimRangeData = initializeXYDimsAndRanges(_chart)
     const xRanges = dimRangeData.xRanges
     const yRanges = dimRangeData.yRanges

--- a/src/mixins/scatter-mixin.js
+++ b/src/mixins/scatter-mixin.js
@@ -15,11 +15,14 @@ export default function scatterMixin(_chart, _mapboxgl, mixinDraw = true) {
 
   _chart._xDimName = null
   _chart._yDimName = null
+  _chart._y2DimName = null
   let _xDim = null
   let _yDim = null
+  let _y2Dim = null
 
   let _xRange = null
   let _yRange = null
+  let _y2Range = null
 
   const _map = {
     remove() {
@@ -57,11 +60,14 @@ export default function scatterMixin(_chart, _mapboxgl, mixinDraw = true) {
   function initializeXYDimsAndRanges(chart) {
     const xDims = []
     const yDims = []
+    const y2Dims = []
     const xRanges = []
     const yRanges = []
+    const y2Ranges = []
 
     addDimAndRange(chart.xDim(), xDims, xRanges)
     addDimAndRange(chart.yDim(), yDims, yRanges)
+    addDimAndRange(chart.y2Dim(), y2Dims, y2Ranges)
 
     if (typeof chart.getLayers === "function") {
       _chart.getLayers().forEach(layer => {
@@ -69,8 +75,17 @@ export default function scatterMixin(_chart, _mapboxgl, mixinDraw = true) {
           addDimAndRange(layer.xDim(), xDims, xRanges)
         }
 
-        if (typeof layer.yDim === "function") {
-          addDimAndRange(layer.yDim(), yDims, yRanges)
+        if (
+          _chart.useTwoYAxes() &&
+          layer.layerType() === "crossSectionTerrain"
+        ) {
+          if (typeof layer.yDim === "function") {
+            addDimAndRange(layer.yDim(), y2Dims, y2Ranges)
+          }
+        } else {
+          if (typeof layer.yDim === "function") {
+            addDimAndRange(layer.yDim(), yDims, yRanges)
+          }
         }
       })
     }
@@ -179,6 +194,10 @@ export default function scatterMixin(_chart, _mapboxgl, mixinDraw = true) {
     return _yRange
   }
 
+  _chart.y2Range = function() {
+    return _y2Range
+  }
+
   _chart.xDim = function(xDim) {
     if (!arguments.length) {
       return _xDim
@@ -212,6 +231,24 @@ export default function scatterMixin(_chart, _mapboxgl, mixinDraw = true) {
     // query during the getDataRenderBounds()
     // function
     _yRange = null
+    return _chart
+  }
+
+  _chart.y2Dim = function(y2Dim) {
+    if (!arguments.length) {
+      return _y2Dim
+    }
+    _y2Dim = y2Dim
+    if (_y2Dim) {
+      _chart._y2DimName = _y2Dim.value()[0]
+    }
+
+    // force a refresh of the render bounds
+    // this currently doesn't improve anything.
+    // We'd want to do this if we do a min/max
+    // query during the getDataRenderBounds()
+    // function
+    _y2Range = null
     return _chart
   }
 

--- a/src/mixins/scatter-mixin.js
+++ b/src/mixins/scatter-mixin.js
@@ -76,16 +76,13 @@ export default function scatterMixin(_chart, _mapboxgl, mixinDraw = true) {
         }
 
         if (
+          typeof layer.yDim === "function" &&
           _chart.useTwoYAxes() &&
           layer.layerType() === "crossSectionTerrain"
         ) {
-          if (typeof layer.yDim === "function") {
-            addDimAndRange(layer.yDim(), y2Dims, y2Ranges)
-          }
-        } else {
-          if (typeof layer.yDim === "function") {
-            addDimAndRange(layer.yDim(), yDims, yRanges)
-          }
+          addDimAndRange(layer.yDim(), y2Dims, y2Ranges)
+        } else if (typeof layer.yDim === "function") {
+          addDimAndRange(layer.yDim(), yDims, yRanges)
         }
       })
     }


### PR DESCRIPTION
### :speech_balloon: Description

Adds support for adding an additional y-axis to the coordinate-grid-raster-mixin, currently used by backend scatter, cross section, and cross section terrain.  Modifies the mixin and its HTML generation process to support right y-axis rendering when `useTwoYAxes` is set.  Additionally, adds a `chart.y2` prop, which is then set in the presence of a multi-layered cross section chart based on the terrain layer.  While this currently will always ensure the terrain layer gets the y2 axis, this should allow any layer to take the y2-axis with slight future modifications.  

### :page_facing_up: Jira Issue

Closes [FE-16795](https://heavyai.atlassian.net/browse/FE-16795) [FE-16796](https://heavyai.atlassian.net/browse/FE-16796)

### :mag: Verification Steps

1. Create a cross section chart, make sure only left y-axis appears with correct scale
2. Add a terrain layer, make sure only left y-axis appears with correct scale for layer
3. Switch to master tab, ensure multi-layered chart is rendered and a new y-axis appears on the right
4. Ensure left y-axis has the correct scale for normal CS chart, while right y-axis has the correct scale for terrain chart

### :camera_flash: Screenshot
![2023-05-25-122808_3418x1915_scrot](https://github.com/heavyai/heavyai-charting/assets/15268289/9f224bfc-de27-4bb1-9d7d-42088547546d)


[FE-16795]: https://heavyai.atlassian.net/browse/FE-16795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FE-16796]: https://heavyai.atlassian.net/browse/FE-16796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ