### PR TITLE
[FE-16842] Show legend in bottom left for mesh2d layers (cross section)

### DIFF
--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -5,8 +5,8 @@ import { format } from "d3-format"
 import { logger } from "../utils/logger"
 
 export const LEGEND_POSITIONS = {
-  TOP_RIGHT: 'top-right',
-  BOTTOM_LEFT: 'bottom-left'
+  TOP_RIGHT: "top-right",
+  BOTTOM_LEFT: "bottom-left"
 }
 
 const hasLegendOpenProp = color =>
@@ -117,7 +117,7 @@ export function getLegendStateFromChart(chart, useMap, selectedLayer) {
       .filter((d, i) => i !== selectedLayer.currentLayer)
       .remove()
   }
-  
+
   return toLegendState(
     getRealLayers(chart.getLayerNames()).map(layer_name => {
       const layer = chart.getLayer(layer_name)
@@ -326,8 +326,9 @@ const color_literal_alpha_regex = /^\s*[a-z,A-Z]{3}[aA]\s*\([\d.]+,[\d.]+,[\d.]+
 
 // eslint-disable-next-line complexity
 function legendState_v1(state, useMap) {
-
-  const position = useMap ? LEGEND_POSITIONS.BOTTOM_LEFT : LEGEND_POSITIONS.TOP_RIGHT
+  const position = useMap
+    ? LEGEND_POSITIONS.BOTTOM_LEFT
+    : LEGEND_POSITIONS.TOP_RIGHT
   if (state.type === "ordinal") {
     return {
       type: "nominal",
@@ -346,7 +347,7 @@ function legendState_v1(state, useMap) {
           ? state.range.concat([state.defaultOtherRange]) // When Other is toggled OFF, don't show color swatch in legend
           : state.range,
       domain: state.hideOther ? state.domain : state.domain.concat(["Other"]),
-      position 
+      position
     }
   } else if (
     state.type === "quantitative" &&
@@ -397,7 +398,9 @@ function legendState_v2(state, useMap) {
   const { title = "Legend", open = true, locked = false } = legend
 
   // Try to default legend position, but take explicit legend_position if it exists
-  let position = useMap ? LEGEND_POSITIONS.BOTTOM_LEFT : LEGEND_POSITIONS.TOP_RIGHT
+  let position = useMap
+    ? LEGEND_POSITIONS.BOTTOM_LEFT
+    : LEGEND_POSITIONS.TOP_RIGHT
   if (state.legend_position) {
     position = state.legend_position
   }

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -4,6 +4,11 @@ import assert from "assert"
 import { format } from "d3-format"
 import { logger } from "../utils/logger"
 
+export const LEGEND_POSITIONS = {
+  TOP_RIGHT: 'top-right',
+  BOTTOM_LEFT: 'bottom-left'
+}
+
 const hasLegendOpenProp = color =>
   typeof color.legend === "object" && color.legend.hasOwnProperty("open")
 const hasLegendLockedProp = color =>
@@ -112,7 +117,7 @@ export function getLegendStateFromChart(chart, useMap, selectedLayer) {
       .filter((d, i) => i !== selectedLayer.currentLayer)
       .remove()
   }
-
+  
   return toLegendState(
     getRealLayers(chart.getLayerNames()).map(layer_name => {
       const layer = chart.getLayer(layer_name)
@@ -120,7 +125,8 @@ export function getLegendStateFromChart(chart, useMap, selectedLayer) {
         const vega = chart.getMaterializedVegaSpec()
         const [
           color_scale,
-          color_legend
+          color_legend,
+          legend_position
         ] = layer.getPrimaryColorScaleAndLegend()
         if (color_scale === null) {
           return {}
@@ -136,6 +142,7 @@ export function getLegendStateFromChart(chart, useMap, selectedLayer) {
         return {
           ...materialized_color_scale,
           legend: color_legend,
+          legend_position,
           version: 2.0
         }
       } else {
@@ -319,6 +326,8 @@ const color_literal_alpha_regex = /^\s*[a-z,A-Z]{3}[aA]\s*\([\d.]+,[\d.]+,[\d.]+
 
 // eslint-disable-next-line complexity
 function legendState_v1(state, useMap) {
+
+  const position = useMap ? LEGEND_POSITIONS.BOTTOM_LEFT : LEGEND_POSITIONS.TOP_RIGHT
   if (state.type === "ordinal") {
     return {
       type: "nominal",
@@ -337,7 +346,7 @@ function legendState_v1(state, useMap) {
           ? state.range.concat([state.defaultOtherRange]) // When Other is toggled OFF, don't show color swatch in legend
           : state.range,
       domain: state.hideOther ? state.domain : state.domain.concat(["Other"]),
-      position: useMap ? "bottom-left" : "top-right"
+      position 
     }
   } else if (
     state.type === "quantitative" &&
@@ -351,7 +360,7 @@ function legendState_v1(state, useMap) {
       open: hasLegendOpenProp(state) ? state.legend.open : true,
       range: state.range,
       domain: state.domain.slice(1),
-      position: useMap ? "bottom-left" : "top-right"
+      position
     }
   } else if (state.type === "quantitative") {
     return {
@@ -361,7 +370,7 @@ function legendState_v1(state, useMap) {
       open: hasLegendOpenProp(state) ? state.legend.open : true,
       range: state.range,
       domain: state.domain,
-      position: "bottom-left"
+      position: LEGEND_POSITIONS.BOTTOM_LEFT
     }
   } else if (state.type === "quantize") {
     const { scale } = state
@@ -372,7 +381,7 @@ function legendState_v1(state, useMap) {
       open: hasLegendOpenProp(state) ? state.legend.open : true,
       range: scale.range,
       domain: scale.domain,
-      position: "bottom-left"
+      position: LEGEND_POSITIONS.BOTTOM_LEFT
     }
   } else {
     return {}
@@ -386,7 +395,12 @@ function legendState_v2(state, useMap) {
   const { legend = {} } = state
   assert(typeof legend === "object")
   const { title = "Legend", open = true, locked = false } = legend
-  const position = useMap ? "bottom-left" : "top-right"
+
+  // Try to default legend position, but take explicit legend_position if it exists
+  let position = useMap ? LEGEND_POSITIONS.BOTTOM_LEFT : LEGEND_POSITIONS.TOP_RIGHT
+  if (state.legend_position) {
+    position = state.legend_position
+  }
 
   if (state_type === "ordinal") {
     const extra_domain = []
@@ -507,7 +521,7 @@ function legendState_v2(state, useMap) {
       open,
       position,
       range: range.slice(0, min_size),
-      domain: domain.slice(0, min_size)
+      domain: domain.slice(0, min_size).map(formatNumber)
     }
   } else {
     return {}
@@ -540,6 +554,7 @@ function validateQuantizeDomain(state) {
 }
 function legendState(state, useMap = true) {
   const { version = 1.0 } = state
+
   return version >= 2.0
     ? legendState_v2(state, useMap)
     : legendState_v1(state, useMap)

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -16,7 +16,6 @@ import { Legend } from "legendables"
 import * as _ from "lodash"
 import { paused } from "../constants/paused"
 import { shallowCopyVega } from "../utils/utils-vega"
-import assert from "assert"
 
 export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
   let _chart = null

--- a/src/mixins/raster-layer-mesh2d-mixin.js
+++ b/src/mixins/raster-layer-mesh2d-mixin.js
@@ -17,6 +17,7 @@ import { materializePropDescriptors } from "./render-vega-lite/RenderVegaLite"
 // only used for jsdoc
 // eslint-disable-next-line no-unused-vars
 import VegaPropertyOutputState from "./render-vega-lite/VegaPropertyOutputState"
+import { LEGEND_POSITIONS } from "../chart-addons/stacked-legend"
 
 // eslint-disable-next-line no-warning-comments
 // TODO(croot): this seems like it is used in at least one other layer mixin. Make into a utility somewhere
@@ -239,7 +240,7 @@ export default function rasterLayerMesh2dMixin(_layer) {
     const legend_obj = prop_descriptor
       ? _vega_property_output_state.getLegendForProperty(prop_descriptor)
       : null
-    return [scale_obj, legend_obj]
+    return [scale_obj, legend_obj, LEGEND_POSITIONS.BOTTOM_LEFT]
   }
 
   _layer.useProjection = function() {


### PR DESCRIPTION
😌  The position was all driven from the `useMap` argument passed to raster chart. This enabled individual layers to determine their own legend position but falls back to the `useMap` logic

This also calls the same format function that legend v1 calls so we don't get crazy precision in the legend values (eg. 45.123853434534)

Before
<img width="762" alt="Screen Shot 2023-06-06 at 5 07 32 PM" src="https://github.com/heavyai/heavyai-charting/assets/1031659/2a04d832-decf-4f0e-8450-b663885b33d7">



After:

Legend Position:
<img width="1079" alt="Screen Shot 2023-06-06 at 5 01 05 PM" src="https://github.com/heavyai/heavyai-charting/assets/1031659/ae716797-27b7-4193-9a02-10e6da26278b">

Format legend values:
<img width="142" alt="Screen Shot 2023-06-06 at 5 06 48 PM" src="https://github.com/heavyai/heavyai-charting/assets/1031659/93f7823c-f48a-4c9b-a0fa-4ba33e53c8c8">


# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
