### PR TITLE
[FE-16757] [FE-16756] Fix lat/lon validation, send maxZoom and padding to mapbox

### DIFF
--- a/src/mixins/map-mixin.js
+++ b/src/mixins/map-mixin.js
@@ -1029,7 +1029,7 @@ export default function mapMixin(
       !isNaN(sw[1]) &&
       !isNaN(ne[1]) &&
       sw[0] <= ne[0] &&
-      sw[1] < ne[1] &&
+      sw[1] <= ne[1] &&
       sw[0] >= LONMIN &&
       sw[0] <= LONMAX &&
       sw[1] >= LATMIN &&
@@ -1050,7 +1050,9 @@ export default function mapMixin(
       if (validateBounds(data)) {
         _map.fitBounds([data.bounds.sw, data.bounds.ne], {
           linear: true,
-          duration: EASE_DURATION_MS
+          duration: EASE_DURATION_MS,
+          maxZoom: data?.maxZoom ?? 22,
+          padding: data?.padding ?? 0
         })
       }
     } else {


### PR DESCRIPTION
Fixes the lat/lon validation function, so that a single point (with identical lat and lon bounds) can be zoomed to.  In addition, pushes the `maxZoom` level and padding sent from immerse to the mapbox api.

For more details, see: https://github.com/heavyai/immerse/pull/8950