### PR TITLE
[FE-17159] Changing the style of the map is affecting layer ordering

### DIFF
--- a/src/mixins/map-mixin.js
+++ b/src/mixins/map-mixin.js
@@ -873,12 +873,14 @@ export default function mapMixin(
 
       _map.on("styledata", () => {
         // reapplying the previous style's render layer to the new style layer when basemap gets changed
+        const firstSymbolLayerId = getFirstSymbolLayerId()
+
         if (savedLayers.length) {
           Object.entries(savedSources).forEach(([id, source]) => {
             if (!_map.getSource(source)) {
               _map.addSource(id, source)
               savedLayers.forEach(layer => {
-                _map.addLayer(layer)
+                _map.addLayer(layer, firstSymbolLayerId)
               })
               savedLayers = []
               savedSources = {}


### PR DESCRIPTION
Positioning layer wasn't passed when re-adding render layer on style change. This should place the render layer under the label layer.