### PR TITLE
[FE-17163] Add forceResize property

### DIFF
--- a/src/mixins/map-mixin.js
+++ b/src/mixins/map-mixin.js
@@ -788,11 +788,11 @@ export default function mapMixin(
       _lastWidth = width
       _lastHeight = height
 
-      // this is a dumb hack, but it works and there doesn't seem to be another sensible way
+      // this is a dumb hack, but it works and there doesn't seem to be another sensible way.
       // problem is, mapbox looks to the size of "mapboxgl-canvas-container" to determine the
       // render size of the canvas, regardless of what we feed it above. if there is an overlay
       // drawer open, even if it sits at a higher z-index, the canvas size will be calculated
-      // according to the physical space in the DOM. Thus, force the canvas container to be the
+      // according to the physical space in the DOM. thus, force the canvas container to be the
       // size of the chart (which ignores the overlay), and reset it once mapbox is done resizing
       if (_overlayDrawerOpen) {
         _chart

--- a/src/mixins/map-mixin.js
+++ b/src/mixins/map-mixin.js
@@ -72,6 +72,7 @@ export default function mapMixin(
   const _minMaxCache = {}
   let _interactionsEnabled = true
   let _shouldRedrawAll = false
+  let _forceResize = false
 
   _chart.useLonLat = function(useLonLat) {
     if (!arguments.length) {
@@ -135,6 +136,13 @@ export default function mapMixin(
 
   _chart.setShouldRedrawAll = function(newShouldRedrawAll) {
     _shouldRedrawAll = newShouldRedrawAll
+  }
+
+  _chart.forceResize = function(forceResize) {
+    if (forceResize !== undefined) {
+      _forceResize = forceResize
+    }
+    return _forceResize
   }
 
   function makeBoundsArrSafe([[lowerLon, lowerLat], [upperLon, upperLat]]) {
@@ -762,7 +770,7 @@ export default function mapMixin(
     const width = chart.width()
     const height = chart.height()
 
-    if (width !== _lastWidth || height !== _lastHeight) {
+    if (width !== _lastWidth || height !== _lastHeight || _forceResize) {
       _chart
         .root()
         .select("#" + _mapId + " canvas")
@@ -772,6 +780,10 @@ export default function mapMixin(
       _lastWidth = width
       _lastHeight = height
       _map.resize()
+
+      if (_forceResize) {
+        _forceResize = false
+      }
     }
   })
 

--- a/src/mixins/map-mixin.js
+++ b/src/mixins/map-mixin.js
@@ -792,7 +792,7 @@ export default function mapMixin(
       // problem is, mapbox looks to the size of "mapboxgl-canvas-container" to determine the
       // render size of the canvas, regardless of what we feed it above. if there is an overlay
       // drawer open, even if it sits at a higher z-index, the canvas size will be calculated
-      // according to the physical space in the DOM. thus, force the canvas container to be the
+      // according to the container's visible width. thus, force the canvas container to be the
       // size of the chart (which ignores the overlay), and reset it once mapbox is done resizing
       if (_overlayDrawerOpen) {
         _chart

--- a/src/mixins/map-mixin.js
+++ b/src/mixins/map-mixin.js
@@ -795,15 +795,15 @@ export default function mapMixin(
       // according to the physical space in the DOM. Thus, force the canvas container to be the
       // size of the chart (which ignores the overlay), and reset it once mapbox is done resizing
       if (_overlayDrawerOpen) {
-        document.getElementsByClassName(
-          "mapboxgl-canvas-container"
-        )[0].style.width = `${width}px`
-
+        _chart
+          .root()
+          .select(`#${_mapId} .mapboxgl-canvas-container`)
+          .style("width", `${width}px`)
         _map.resize()
-
-        document.getElementsByClassName(
-          "mapboxgl-canvas-container"
-        )[0].style.width = "auto"
+        _chart
+          .root()
+          .select(`#${_mapId} .mapboxgl-canvas-container`)
+          .style("width", "auto")
       } else {
         _map.resize()
       }


### PR DESCRIPTION
Adds forceResize property, which will bypass width/height delta checks to force a resize (needed for layer drawer, as chart will have same w/h but needs a resize since mapbox is detecting the size of the actual canvas element and will thus leave a gray area once the drawer is gone).

Now also includes hack to get mapbox to cooperate when we have an overlay drawer rendered overtop of it.