### PR TITLE
[FE-17191] Join to geo support

### DIFF
--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import {
   createRasterLayerGetterSetter,
   createVegaAttrMixin,

--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -104,7 +104,6 @@ export default function rasterLayerLineMixin(_layer) {
     return state
   }
 
-
   function doJoin() {
     return state.data.length > 1
   }
@@ -172,7 +171,7 @@ export default function rasterLayerLineMixin(_layer) {
         as: "sampled_geo"
       })
     } else if (isJoin) {
-      // Group by geometry by assuming all rows are a unique 
+      // Group by geometry by assuming all rows are a unique
       // geometry, and grouping by rowid
       transforms.push({
         type: "aggregate",
@@ -188,7 +187,7 @@ export default function rasterLayerLineMixin(_layer) {
         expr: `ANY_VALUE(${geoTable}.${geocol})`,
         as: geocol
       })
-    }else {
+    } else {
       transforms.push({
         type: "project",
         expr: `${isDataExport ? "/*+ cpu_mode */ " : ""}${geoTable}.${geocol}`
@@ -401,7 +400,9 @@ export default function rasterLayerLineMixin(_layer) {
         filterTransforms
       })
     } else {
-      const source = doJoin() ? [...new Set(state.data.map(source => source.table))].join(", ") : table
+      const source = doJoin()
+        ? [...new Set(state.data.map(source => source.table))].join(", ")
+        : table
       sql = parser.writeSQL({
         type: "root",
         source,

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -165,7 +165,6 @@ export default function rasterLayerPolyMixin(_layer) {
 
     const transforms = []
 
-    // Adds *+ cpu_mode */ in data export query since we are limiting to some number of rows.
     if (isJoin) {
         // add group by
         const groupby = {
@@ -180,7 +179,7 @@ export default function rasterLayerPolyMixin(_layer) {
           fields: [],
           ops: [null],
           as: [],
-          groupby
+          groupby: `${geoTable}.rowid`
         })
 
         // Select any_value, as the original col name
@@ -190,7 +189,7 @@ export default function rasterLayerPolyMixin(_layer) {
           as: geocol
         })
     } else {
-
+      // Adds *+ cpu_mode */ in data export query since we are limiting to some number of rows.
       transforms.push({
         type: "project",
         expr: `${
@@ -371,7 +370,7 @@ export default function rasterLayerPolyMixin(_layer) {
               [
                 {
                   type: filtersInverse ? "not in" : "in",
-                  expr: "rowid",
+                  expr: `${state.encoding.geoTable}.rowid`,
                   set: layerFilter
                 },
                 // Note: When not performing a join, there is no dimension,
@@ -391,7 +390,7 @@ export default function rasterLayerPolyMixin(_layer) {
           type: "filter",
           expr: parser.parseExpression({
             type: filtersInverse ? "not in" : "in",
-            expr: "rowid",
+            expr: `${state.encoding.geoTable}.rowid`,
             set: layerFilter
           })
         })
@@ -956,7 +955,7 @@ export default function rasterLayerPolyMixin(_layer) {
     }
     const isInverseFilter = Boolean(event && (event.metaKey || event.ctrlKey))
 
-    const filterKey = "key0" in data ? "key0" : "rowid"
+    const filterKey = "key0" in data ? "key0" : `rowid`
 
     chart.hidePopup()
     events.trigger(() => {

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -354,7 +354,6 @@ export default function rasterLayerPolyMixin(_layer) {
           as: "color"
         })
       }
-      // }
 
       if (layerFilter.length && !isDataExport) {
         transforms.push({
@@ -947,7 +946,7 @@ export default function rasterLayerPolyMixin(_layer) {
     }
     const isInverseFilter = Boolean(event && (event.metaKey || event.ctrlKey))
 
-    const filterKey = "key0" in data ? "key0" : `rowid`
+    const filterKey = "key0" in data ? "key0" : "rowid"
 
     chart.hidePopup()
     events.trigger(() => {

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -167,7 +167,7 @@ export default function rasterLayerPolyMixin(_layer) {
     const transforms = []
 
     if (isJoin) {
-      // Group by geometry by assuming all rows are a unique 
+      // Group by geometry by assuming all rows are a unique
       // geometry, and grouping by rowid
       transforms.push({
         type: "aggregate",

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -154,7 +154,10 @@ export default function rasterLayerPolyMixin(_layer) {
     isDataExport
   }) {
     /* eslint complexity: ["error", 50] */ // this function is too complex. Sorry.
-    // Find a much better way to do this... set a flag in immerse?
+
+    // If crossfilter has > 1 table it is a join data source
+    // If this is true, we add an automatic group by for geometry rowid, and use
+    // ANY_VALUE to project unique geometries
     const isJoin = _layer?.dimension()?.crossfilter?.getTables()?.length > 1
 
     const {
@@ -164,14 +167,8 @@ export default function rasterLayerPolyMixin(_layer) {
     const transforms = []
 
     if (isJoin) {
-      // add group by
-      const groupby = {
-        type: "project",
-        expr: `${geoTable}.rowid`,
-        as: "grouped_geom"
-      }
-
-      // Group by geometry (more of less)
+      // Group by geometry by assuming all rows are a unique 
+      // geometry, and grouping by rowid
       transforms.push({
         type: "aggregate",
         fields: [],

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -905,7 +905,7 @@ export default function rasterLayerPolyMixin(_layer) {
       // when poly selection filter cleared, we reapply the bbox filter for the NON geo joined poly
       // For geo joined poly, we don't run crossfilter
       if (
-        _layer?.getState?.()?.data?.length < 2
+        _layer?.getState()?.data?.length ?? 0 < 2
       ) {
         const viewboxdim = _layer.dimension().set(() => [geoTableCol])
         const mapBounds = chart.map().getBounds()


### PR DESCRIPTION
Big Changes:
* Updates transforms for line and poly mixins, so that if the datasource is a join it will group by the geometry table's `rowid`
* Line map wasn't using the join datasource properly, if it detects that the layer uses a join datasource it uses `table`which is the join datasource parameter, which will be processed to the full syntax down the line. 
* Use full `table.column` expression for rowid because for join data sources both tables have a rowid. 
* Some syntax improvements


# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
