### PR TITLE
[FE-17174] Check to make sure a source with id doesn't already exist to avoid mapbox error

### DIFF
--- a/src/mixins/map-mixin.js
+++ b/src/mixins/map-mixin.js
@@ -916,7 +916,7 @@ export default function mapMixin(
 
         if (savedLayers.length) {
           Object.entries(savedSources).forEach(([id, source]) => {
-            if (!_map.getSource(source)) {
+            if (!_map.getSource(source) && !_map.getSource(id)) {
               _map.addSource(id, source)
               savedLayers.forEach(layer => {
                 _map.addLayer(layer, firstSymbolLayerId)


### PR DESCRIPTION
If you zoom in the chart editor and cancel, you will occasionally run into a mapbox error saying "a source with this id already exists".  Add an additional check by source id to ensure the source doesn't already exist and avoid console error if it does.