### PR TITLE
[FE-17341] Fix divide by 0 error, handle large bin_dim_meters param values

### DIFF
--- a/src/utils/utils-contour.js
+++ b/src/utils/utils-contour.js
@@ -15,7 +15,7 @@ const buildParamsSQL = (params = {}) =>
       const stringParams = ["agg_type", "fill_agg_type"]
       let parsedVal = val
       if (floatParams.includes(key)) {
-        parsedVal = Number.parseFloat(val).toFixed(1)
+        parsedVal = `cast(${Number.parseFloat(val).toFixed(1)} as float)`
       } else if (stringParams.includes(key)) {
         parsedVal = `'${val}'`
       } else if (typeof val === "boolean") {
@@ -76,8 +76,9 @@ export const buildOptimizedContourSQL = ({
     : ""
 
   const BASE_MULTIPLIER = 100000.0
+  const multiplierDenom = Math.round((BASE_MULTIPLIER * 2.0) / bin_dim_meters) || 1.0
   const multiplier = Number.parseFloat(
-    1 / Math.round((BASE_MULTIPLIER * 2.0) / bin_dim_meters)
+    1 / multiplierDenom
   ).toFixed(10)
 
   const latFieldParsed = is_geo_point_type ? `ST_Y(${lat_field})` : lat_field

--- a/src/utils/utils-contour.js
+++ b/src/utils/utils-contour.js
@@ -76,10 +76,9 @@ export const buildOptimizedContourSQL = ({
     : ""
 
   const BASE_MULTIPLIER = 100000.0
-  const multiplierDenom = Math.round((BASE_MULTIPLIER * 2.0) / bin_dim_meters) || 1.0
-  const multiplier = Number.parseFloat(
-    1 / multiplierDenom
-  ).toFixed(10)
+  const multiplierDenom =
+    Math.round((BASE_MULTIPLIER * 2.0) / bin_dim_meters) || 1.0
+  const multiplier = Number.parseFloat(1 / multiplierDenom).toFixed(10)
 
   const latFieldParsed = is_geo_point_type ? `ST_Y(${lat_field})` : lat_field
   const lonFieldParsed = is_geo_point_type ? `ST_X(${lon_field})` : lon_field


### PR DESCRIPTION
Test Dashboard
`mapd/dashboard/9368?filterSet=-NjJkvetcVtlF9fRxlYw&tab=-NjJkverljUTOKmJnkPn`

This raster has a large enough stride that bin dim meters min/max are quite large. Try setting this value throughout the whole range. 

Very large values caused the original error, and were being forced into incorrect types for the TF by calcite. This forces them to be floats, and prevents our optimization constant from getting to 0. 

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
