### PR TITLE
[FE-16380] Contour chart: Filtering values does not affect overall color range

### DIFF
--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -380,7 +380,7 @@ function legendState_v1(state, useMap) {
       domain: state.domain,
       position: LEGEND_POSITIONS.BOTTOM_LEFT
     }
-  } else if (state.type === "quantize") {
+  } else if (state.type === "quantize" && state.domain !== "auto-contour") { // Legend not supported for contour
     const { scale } = state
     return {
       type: "gradient",

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -380,7 +380,8 @@ function legendState_v1(state, useMap) {
       domain: state.domain,
       position: LEGEND_POSITIONS.BOTTOM_LEFT
     }
-  } else if (state.type === "quantize" && state.domain !== "auto-contour") { // Legend not supported for contour
+  } else if (state.type === "quantize" && state.domain !== "auto-contour") {
+    // Legend not supported for contour
     const { scale } = state
     return {
       type: "gradient",

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -670,7 +670,7 @@ export default function rasterLayerPolyMixin(_layer) {
     if (isContourType(state)) {
       scales.push({
         name: `${layerName}_contour_fill`,
-        type: "quantize",
+        type: state.encoding.color.type,
         domain: contourAutocolors
           ? {
               data: getStatsLayerName(layerName),

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -644,13 +644,32 @@ export default function rasterLayerPolyMixin(_layer) {
       })
     }
 
+    if (isContourType(state)) {
+      data.push({
+        name: getStatsLayerName(layerName),
+        source: layerName,
+        transform: [
+          {
+            type: "aggregate",
+            fields: ["contour_values", "contour_values"],
+            ops: ["min", "max"],
+            as: ["mincol", "maxcol"]
+          }
+        ]
+      })
+    }
+
     const scales = []
     let fillColor = "#AAAAAA"
     if (isContourType(state)) {
       scales.push({
         name: `${layerName}_contour_fill`,
-        type: state.encoding.color.type,
-        domain: state.encoding.color.domain,
+        type: "quantize",
+        // domain: state.encoding.color.domain, //
+        domain: {
+          data: getStatsLayerName(layerName),
+          fields: ["mincol", "maxcol"]
+        },
         range: state.encoding.color.range.map(c =>
           adjustOpacity(c, state.encoding.color.opacity)
         ),

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -671,11 +671,12 @@ export default function rasterLayerPolyMixin(_layer) {
       scales.push({
         name: `${layerName}_contour_fill`,
         type: "quantize",
-        // domain: state.encoding.color.domain, //
-        domain: contourAutocolors ? {
-          data: getStatsLayerName(layerName),
-          fields: ["mincol", "maxcol"]
-        } : state.encoding.color.domain,
+        domain: contourAutocolors
+          ? {
+              data: getStatsLayerName(layerName),
+              fields: ["mincol", "maxcol"]
+            }
+          : state.encoding.color.domain,
         range: state.encoding.color.range.map(c =>
           adjustOpacity(c, state.encoding.color.opacity)
         ),


### PR DESCRIPTION
Adds `auto-contour` color domain handling to calculate domain from min/max; cannot use existing "auto" domain logic as-is as that presumes there is a `color` column. 