### PR TITLE
[FE-17337] Move sample to end of query for metis codegen

### DIFF
--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -237,6 +237,20 @@ export default function rasterLayerLineMixin(_layer) {
       })
     }
 
+    if (typeof filter === "string" && filter.length) {
+      transforms.push({
+        type: "filter",
+        expr: filter
+      })
+    }
+
+    if (typeof globalFilter === "string" && globalFilter.length) {
+      transforms.push({
+        type: "filter",
+        expr: globalFilter
+      })
+    }
+
     if (typeof transform.limit === "number") {
       if (transform.sample && !doJoin()) {
         // use Knuth's hash sampling on single data source chart
@@ -254,20 +268,6 @@ export default function rasterLayerLineMixin(_layer) {
           row: transform.limit
         })
       }
-    }
-
-    if (typeof filter === "string" && filter.length) {
-      transforms.push({
-        type: "filter",
-        expr: filter
-      })
-    }
-
-    if (typeof globalFilter === "string" && globalFilter.length) {
-      transforms.push({
-        type: "filter",
-        expr: globalFilter
-      })
     }
 
     return transforms

--- a/src/mixins/raster-layer-point-mixin.js
+++ b/src/mixins/raster-layer-point-mixin.js
@@ -477,10 +477,6 @@ export default function rasterLayerPointMixin(_layer) {
       layerName,
       markType
     )
-    console.log("SIZE")
-    console.log(size)
-    console.log("STATE")
-    console.log(state)
 
     let data = []
 
@@ -531,40 +527,6 @@ export default function rasterLayerPointMixin(_layer) {
         }
       }
     } else {
-      console.log("TRANSFORMS")
-      console.log(
-        _layer.getTransforms(
-          table,
-          filter,
-          globalFilter,
-          state,
-          lastFilteredSize
-        )
-      )
-      const transforms = _layer.getTransforms(
-        table,
-        filter,
-        globalFilter,
-        state,
-        lastFilteredSize
-      )
-      parser.writeSQL({
-        type: "root",
-        source: table,
-        transform: transforms
-      })
-      console.log("WRITE SQL")
-      parser.writeSQL({
-        type: "root",
-        source: table,
-        transform: _layer.getTransforms(
-          table,
-          filter,
-          globalFilter,
-          state,
-          lastFilteredSize
-        )
-      })
       data = [
         {
           name: layerName,

--- a/src/mixins/raster-layer-point-mixin.js
+++ b/src/mixins/raster-layer-point-mixin.js
@@ -270,22 +270,6 @@ export default function rasterLayerPointMixin(_layer) {
         })
       }
 
-      if (typeof transform.limit === "number") {
-        transforms.push({
-          type: "limit",
-          row: transform.limit
-        })
-        if (transform.sample) {
-          transforms.push({
-            type: "sample",
-            method: "multiplicative",
-            size: lastFilteredSize || transform.tableSize,
-            limit: transform.limit,
-            sampleTable: table
-          })
-        }
-      }
-
       if (typeof size === "object" && size.type === "quantitative") {
         transforms.push({
           type: "project",
@@ -340,6 +324,22 @@ export default function rasterLayerPointMixin(_layer) {
         type: "filter",
         expr: globalFilter
       })
+    }
+
+    if (typeof transform.limit === "number") {
+      transforms.push({
+        type: "limit",
+        row: transform.limit
+      })
+      if (transform.sample) {
+        transforms.push({
+          type: "sample",
+          method: "multiplicative",
+          size: lastFilteredSize || transform.tableSize,
+          limit: transform.limit,
+          sampleTable: table
+        })
+      }
     }
 
     return transforms
@@ -477,6 +477,10 @@ export default function rasterLayerPointMixin(_layer) {
       layerName,
       markType
     )
+    console.log("SIZE")
+    console.log(size)
+    console.log("STATE")
+    console.log(state)
 
     let data = []
 
@@ -527,6 +531,40 @@ export default function rasterLayerPointMixin(_layer) {
         }
       }
     } else {
+      console.log("TRANSFORMS")
+      console.log(
+        _layer.getTransforms(
+          table,
+          filter,
+          globalFilter,
+          state,
+          lastFilteredSize
+        )
+      )
+      const transforms = _layer.getTransforms(
+        table,
+        filter,
+        globalFilter,
+        state,
+        lastFilteredSize
+      )
+      parser.writeSQL({
+        type: "root",
+        source: table,
+        transform: transforms
+      })
+      console.log("WRITE SQL")
+      parser.writeSQL({
+        type: "root",
+        source: table,
+        transform: _layer.getTransforms(
+          table,
+          filter,
+          globalFilter,
+          state,
+          lastFilteredSize
+        )
+      })
       data = [
         {
           name: layerName,

--- a/src/mixins/raster-layer-point-mixin.unit.spec.js
+++ b/src/mixins/raster-layer-point-mixin.unit.spec.js
@@ -141,8 +141,8 @@ describe("rasterLayerPointMixin", () => {
           "SELECT conv_4326_900913_x(lon) AS x, "
           + "conv_4326_900913_y(lat) AS y "
           + "FROM tweets_nov_feb "
-          + "WHERE SAMPLE_RATIO(0.0016816902723414068) "
-          + "AND (lon = 100) LIMIT 2000000"
+          + "WHERE (lon = 100) "
+          + "AND SAMPLE_RATIO(0.0016816902723414068) LIMIT 2000000"
         )
 
       })

--- a/src/mixins/raster-layer-windbarb-mixin.js
+++ b/src/mixins/raster-layer-windbarb-mixin.js
@@ -148,22 +148,6 @@ export default function rasterLayerWindBarbMixin(_layer) {
         })
       }
 
-      if (typeof transform.limit === "number") {
-        transforms.push({
-          type: "limit",
-          row: transform.limit
-        })
-        if (transform.sample) {
-          transforms.push({
-            type: "sample",
-            method: "multiplicative",
-            size: lastFilteredSize || transform.tableSize,
-            limit: transform.limit,
-            sampleTable: table
-          })
-        }
-      }
-
       if (typeof size === "object" && size.type === "quantitative") {
         transforms.push({
           type: "project",
@@ -201,6 +185,22 @@ export default function rasterLayerWindBarbMixin(_layer) {
         type: "filter",
         expr: globalFilter
       })
+    }
+
+    if (typeof transform.limit === "number") {
+      transforms.push({
+        type: "limit",
+        row: transform.limit
+      })
+      if (transform.sample) {
+        transforms.push({
+          type: "sample",
+          method: "multiplicative",
+          size: lastFilteredSize || transform.tableSize,
+          limit: transform.limit,
+          sampleTable: table
+        })
+      }
     }
 
     return transforms


### PR DESCRIPTION
This moved the `SAMPLE_RATIO` part of the query codegen in metis to the end of the `WHERE` clause.  See ticket for details.

We may need to fix this for contour as well, but need to consult with Dr. Flaxman.  This addresses the immediate SCE issue.