### PR TITLE
[YOLO] Fixes examples bundle name heavyai-charting -> app

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -2,7 +2,7 @@ const path = require("path")
 
 module.exports = {
   entry: {
-    "heavyai-charting": [
+    "app": [
       "script-loader!@heavyai/connector/dist/browser-connector.js",
       "script-loader!@heavyai/crossfilter/dist/mapd-crossfilter.js",
       "script-loader!@heavyai/d3-combo-chart/dist/d3ComboChart.js",


### PR DESCRIPTION
Broken here: https://github.com/heavyai/heavyai-charting/pull/585/files#diff-7dd57a4f662248b39cb60c9020a05a60bad59359a915a5ac35b9699cf7bf1095L6

But all of the examples still import `app.bundle.js` which is named after this property, not sure why the change was included as part of that. Fixes use of global variables like `DbCon` in the examples.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
