### PR TITLE
[FE-17686] Human-readable missing hit test cols error string

### DIFF
--- a/src/charts/heatmap.js
+++ b/src/charts/heatmap.js
@@ -492,7 +492,7 @@ export default function heatMap(parent, chartGroup) {
     rows = _rowScale.domain(rows)
     cols = _colScale.domain(cols)
     _chart.dockedAxesSize(_chart.getAxisSizes(cols.domain(), rows.domain()))
-    let rowCount = rows.domain().length,
+    const rowCount = rows.domain().length,
       colCount = cols.domain().length,
       availWidth = _chart.width() - _dockedAxesSize.left,
       availHeight = _chart.height() - _dockedAxesSize.bottom,

--- a/src/charts/row-chart.js
+++ b/src/charts/row-chart.js
@@ -560,7 +560,7 @@ export default function rowChart(parent, chartGroup) {
   /* --------------------------------------------------------------------------*/
 
   function translateX(d) {
-    let x = _x(_chart.cappedValueAccessor(d)),
+    const x = _x(_chart.cappedValueAccessor(d)),
       x0 = rootValue(),
       s = x > x0 ? x0 : x
     return "translate(" + s + ",0)"

--- a/src/mixins/cap-mixin.js
+++ b/src/mixins/cap-mixin.js
@@ -21,7 +21,7 @@ export default function capMixin(_chart) {
   let _othersLabel = "Others"
 
   let _othersGrouper = function(topRows) {
-    let topRowsSum = d3.sum(topRows, _chart.valueAccessor()),
+    const topRowsSum = d3.sum(topRows, _chart.valueAccessor()),
       allRows = _chart.group().all(),
       allRowsSum = d3.sum(allRows, _chart.valueAccessor()),
       topKeys = topRows.map(_chart.keyAccessor()),

--- a/src/mixins/coordinate-grid-mixin.js
+++ b/src/mixins/coordinate-grid-mixin.js
@@ -723,7 +723,7 @@ export default function coordinateGridMixin (_chart) {
       if (_y === undefined) {
         _y = d3.scale.linear()
       }
-      let min = _chart.yAxisMin() || 0,
+      const min = _chart.yAxisMin() || 0,
         max = _chart.yAxisMax() || 0
       _y.domain([min, max]).rangeRound([_chart.yAxisHeight(), 0])
     }
@@ -1363,7 +1363,7 @@ export default function coordinateGridMixin (_chart) {
 
   // borrowed from Crossfilter example
   _chart.resizeHandlePath = function (d) {
-    let e = Number(d === "e"),
+    const e = Number(d === "e"),
       x = e ? 1 : -1,
       y = brushHeight() / 3
     return (

--- a/src/mixins/coordinate-grid-raster-mixin.js
+++ b/src/mixins/coordinate-grid-raster-mixin.js
@@ -214,7 +214,7 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
   }
 
   _chart.unproject = function (pt) {
-    let xscale = _chart.x(),
+    const xscale = _chart.x(),
       yscale = _chart.y()
     const x = (xscale ? xscale.invert(pt.x) : 0)
     const y = (yscale ? yscale.invert(pt.y) : 0)
@@ -1404,7 +1404,7 @@ axis in dc.js is simply an instance of a [d3 axis
 
   // borrowed from Crossfilter example
   _chart.resizeHandlePath = function (d) {
-    let e = Number(d === "e"),
+    const e = Number(d === "e"),
       x = e ? 1 : -1,
       y = brushHeight() / 3
     return "M" + (0.5 * x) + "," + y + "A6,6 0 0 " + e + " " + (6.5 * x) + "," + (y + 6) + "V" + (2 * y - 6) + "A6,6 0 0 " + e + " " + (0.5 * x) + "," + (2 * y) + "Z" + "M" + (2.5 * x) + "," + (y + 8) + "V" + (2 * y - 8) + "M" + (4.5 * x) + "," + (y + 8) + "V" + (2 * y - 8)

--- a/src/mixins/d3.box.js
+++ b/src/mixins/d3.box.js
@@ -17,7 +17,7 @@ import d3 from "d3"
     function box(g) {
       g.each(function(d, i) {
         d = d.map(value).sort(d3.ascending)
-        let g = d3.select(this),
+        const g = d3.select(this),
           n = d.length,
           min = d[0],
           max = d[n - 1]
@@ -26,7 +26,7 @@ import d3 from "d3"
         const quartileData = (d.quartiles = quartiles(d))
 
         // Compute whiskers. Must return exactly 2 elements, or null.
-        let whiskerIndices = whiskers && whiskers.call(this, d, i),
+        const whiskerIndices = whiskers && whiskers.call(this, d, i),
           whiskerData = whiskerIndices && whiskerIndices.map(i => d[i])
 
         // Compute outliers. If no whiskers are specified, all data are 'outliers'.

--- a/src/mixins/raster-layer.js
+++ b/src/mixins/raster-layer.js
@@ -27,7 +27,7 @@ const validLayerTypes = [
 ]
 
 const { getImageSize, replaceAsync, parseUrlParts } = utils
-const missingHitTestColumnErrorStr =
+const MISSING_HIT_TEST_COLUMN_ERROR =
   "$HEAVYAI_ERROR_COLUMN_NOT_FOUND_IN_HIT_TEST_CACHE$"
 
 export default function rasterLayer(layerType) {
@@ -577,7 +577,7 @@ export default function rasterLayer(layerType) {
     // check for missing hit test cache columns and substitute readable message
     // they always come back with string $HEAVYAI_ERROR_COLUMN_NOT_FOUND_IN_HIT_TEST_CACHE$
     for (const [key, value] of Object.entries(mappedColumns)) {
-      if (value === missingHitTestColumnErrorStr) {
+      if (value === MISSING_HIT_TEST_COLUMN_ERROR) {
         mappedColumns[key] = "Column Not Found"
       }
     }

--- a/src/mixins/raster-layer.js
+++ b/src/mixins/raster-layer.js
@@ -27,6 +27,8 @@ const validLayerTypes = [
 ]
 
 const { getImageSize, replaceAsync, parseUrlParts } = utils
+const missingHitTestColumnErrorStr =
+  "$HEAVYAI_ERROR_COLUMN_NOT_FOUND_IN_HIT_TEST_CACHE$"
 
 export default function rasterLayer(layerType) {
   const _layerType = layerType
@@ -571,6 +573,15 @@ export default function rasterLayer(layerType) {
     // popupColumns have color or size measure label
     const popupColumns = _layer.popupColumns()
     const mappedColumns = _layer.popupColumnsMapped()
+
+    // check for missing hit test cache columns and substitute readable message
+    // they always come back with string $HEAVYAI_ERROR_COLUMN_NOT_FOUND_IN_HIT_TEST_CACHE$
+    for (const [key, value] of Object.entries(mappedColumns)) {
+      if (value === missingHitTestColumnErrorStr) {
+        mappedColumns[key] = "Column Not Found"
+      }
+    }
+
     const filteredData = mapDataViaColumns(data, popupColumns, chart)
 
     const width =

--- a/src/mixins/raster-layer.js
+++ b/src/mixins/raster-layer.js
@@ -577,7 +577,6 @@ export default function rasterLayer(layerType) {
     // popupColumns have color or size measure label
     const popupColumns = _layer.popupColumns()
     const mappedColumns = _layer.popupColumnsMapped()
-
     const filteredData = mapDataViaColumns(data, popupColumns, chart)
 
     const width =

--- a/src/mixins/raster-layer.js
+++ b/src/mixins/raster-layer.js
@@ -357,7 +357,11 @@ export default function rasterLayer(layerType) {
     const columnSet = new Set(popupColumns)
     for (const key in data) {
       if (columnSet.has(key)) {
-        newData[key] = data[key]
+        // check for missing hit test cache columns and substitute readable message
+        newData[key] =
+          data[key] === MISSING_HIT_TEST_COLUMN_ERROR
+            ? "Column Not Found"
+            : data[key]
         data[key] instanceof Date ? moment(data[key]).utc() : data[key]
 
         if (typeof chart.useLonLat === "function" && chart.useLonLat()) {
@@ -573,14 +577,6 @@ export default function rasterLayer(layerType) {
     // popupColumns have color or size measure label
     const popupColumns = _layer.popupColumns()
     const mappedColumns = _layer.popupColumnsMapped()
-
-    // check for missing hit test cache columns and substitute readable message
-    // they always come back with string $HEAVYAI_ERROR_COLUMN_NOT_FOUND_IN_HIT_TEST_CACHE$
-    for (const [key, value] of Object.entries(mappedColumns)) {
-      if (value === MISSING_HIT_TEST_COLUMN_ERROR) {
-        mappedColumns[key] = "Column Not Found"
-      }
-    }
 
     const filteredData = mapDataViaColumns(data, popupColumns, chart)
 


### PR DESCRIPTION
Catches missing hit test column error string returned from BE and replaces with human-readable error message.

For proof, here is me forcefully pushing an invalid column into the hit testing, showing the correct error coming back from the BE (and showing no crash):

https://github.com/heavyai/heavyai-charting/assets/15268289/9b229c9d-a6e4-41e0-8e39-a4208be70507

Here is after the FE fix to turn that into a human-readable error message:

https://github.com/heavyai/heavyai-charting/assets/15268289/25e3221c-e4b8-4699-86f6-c89ab597028b


