### PR TITLE
[FE-17705] Dynamically update categorical legend domain

### DIFF
--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -108,15 +108,11 @@ async function getTopValues(layer, size) {
       .group()
       .topAsync(size, OFFSET)
       .then(results => {
-        if (results) {
-          return results.map(result => result.key0)
-        } else {
-          return null
-        }
+        return results?.map(result => result.key0) ?? null
       })
       .catch(error => null)
   } else {
-    return Promise.resolve(null)
+    return null
   }
 }
 
@@ -297,7 +293,9 @@ export function handleLegendOpen(index = 0) {
         : false
     }))
   )
-  this.legend().setState(getLegendStateFromChart(this))
+  getLegendStateFromChart(this).then(state => {
+    this.legend().setState(state)
+  })
 }
 
 export function handleLegendLock({ locked, index = 0 }) {
@@ -341,7 +339,9 @@ export function handleLegendLock({ locked, index = 0 }) {
     if (redraw) {
       this.renderAsync() // not setting the state for the legend here because it'll happen on the redraw
     } else {
-      this.legend().setState(getLegendStateFromChart(this))
+      getLegendStateFromChart(this).then(state => {
+        this.legend().setState(state)
+      })
     }
   }
 }
@@ -371,8 +371,10 @@ export function handleLegendInput({ domain, index = 0 }) {
     )
   }
 
-  this.legend().setState(getLegendStateFromChart(this))
-  this.renderAsync()
+  getLegendStateFromChart(this).then(state => {
+    this.legend().setState(state)
+    this.renderAsync()
+  })
 }
 
 function isQuantitativeType(type_string) {

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -110,7 +110,6 @@ async function getTopValues(layer) {
       .topAsync(NUM_TOP_VALUES, OFFSET)
       .then(results => {
         if (results) {
-          console.log(results)
           return results.map(result => result.key0)
         } else {
           return null
@@ -124,10 +123,16 @@ async function getTopValues(layer) {
   }
 }
 
-function getUpdatedDomainRangeMapping(newDomain, oldDomain, range) {
+function getUpdatedDomainRangeMapping(
+  newDomain,
+  oldDomain,
+  range,
+  defaultColor
+) {
   const oldDomainRangeMap = new Map(
     [...oldDomain].map((key, index) => [key, range[index]])
   )
+  console.log("oldDomainRangeMap:", oldDomainRangeMap)
   // if the newDomain has a color entry in oldDomain, grab that color and assign for the new map
   const newDomainRangeMap = new Map(
     [...newDomain].map((key, index) => [key, oldDomainRangeMap.get(key)])
@@ -135,7 +140,7 @@ function getUpdatedDomainRangeMapping(newDomain, oldDomain, range) {
   console.log("newDomainRangeMap 1", newDomainRangeMap)
   newDomainRangeMap.forEach((val, key) => {
     if (!val) {
-      newDomainRangeMap.set(key, range[0])
+      newDomainRangeMap.set(key, defaultColor)
     }
   })
   console.log("newDomainRangeMap 2", newDomainRangeMap)
@@ -230,12 +235,15 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
               }
             } else if (color.type === "ordinal") {
               const colValues = await getTopValues(layer)
+              console.log("orig domain:", color.domain)
+              console.log("orig range:", color.range)
               const { newDomain, newRange } = getUpdatedDomainRangeMapping(
                 colValues,
                 color.domain,
-                color.range
+                color.range,
+                color.defaultOtherRange
               )
-              console.log(newDomain, newRange)
+              console.log("color, newD and newR:", color, newDomain, newRange)
               color_legend_descriptor = newDomain
                 ? { ...color, domain: newDomain, range: newRange }
                 : { ...color }
@@ -246,7 +254,6 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
             color_legend_descriptor = { ...color }
           }
 
-          console.log("about to return from function", color_legend_descriptor)
           return {
             ...color_legend_descriptor,
             version: 1.0

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -224,11 +224,12 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
                   )
                 : {}
 
-              // don't show "Other" label if our domain is less than the original domain
-              if (newDomain.length < color.domain.length) {
-                color.hideOther = true
-              } else {
-                color.hideOther = false
+              // don't show the other category when new domain is smaller than original max
+              color.otherActive = false
+              if (!color.hideOther && newDomain.length < color.domain.length) {
+                color.otherActive = false
+              } else if (!color.hideOther) {
+                color.otherActive = true
               }
 
               color_legend_descriptor =
@@ -409,10 +410,14 @@ function legendState_v1(state, useMap) {
       range:
         !state.hideOther &&
         state.hasOwnProperty("showOther") &&
-        state.showOther === true
+        state.showOther &&
+        state.otherActive
           ? state.range.concat([state.defaultOtherRange]) // When Other is toggled OFF, don't show color swatch in legend
           : state.range,
-      domain: state.hideOther ? state.domain : state.domain.concat(["Other"]),
+      domain:
+        state.hideOther || !state.otherActive
+          ? state.domain
+          : state.domain.concat(["Other"]),
       position
     }
   } else if (

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -123,12 +123,7 @@ async function getTopValues(layer) {
   }
 }
 
-function getUpdatedDomainRangeMapping(
-  newDomain,
-  oldDomain,
-  range,
-  defaultColor
-) {
+function getUpdatedDomainRange(newDomain, oldDomain, range, defaultColor) {
   const oldDomainRange = new Map(
     [...oldDomain].map((key, index) => [key, range[index]])
   )
@@ -226,15 +221,18 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
               }
             } else if (color.type === "ordinal") {
               const colValues = await getTopValues(layer)
-              const { newDomain, newRange } = getUpdatedDomainRangeMapping(
-                colValues,
-                color.domain,
-                color.range,
-                color.defaultOtherRange
-              )
-              color_legend_descriptor = newDomain
-                ? { ...color, domain: newDomain, range: newRange }
-                : { ...color }
+              const { newDomain, newRange } = colValues
+                ? getUpdatedDomainRange(
+                    colValues,
+                    color.domain,
+                    color.range,
+                    color.defaultOtherRange
+                  )
+                : undefined
+              color_legend_descriptor =
+                newDomain && newRange
+                  ? { ...color, domain: newDomain, range: newRange }
+                  : { ...color }
             } else {
               color_legend_descriptor = { ...color }
             }

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -192,7 +192,6 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
           // form above
           const layerState = layer.getState()
           const color = layer.getState().encoding.color
-          // TODO[C]: the line above is where it is getting everything for the legend, including colors, domain and range
 
           let color_legend_descriptor = null
 

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -100,10 +100,11 @@ function setColorScaleDomain_v1(domain) {
 
 async function getTopValues(layer, layerName, size) {
   const OFFSET = 0
-  const chartId = layer.crossfilter().chartId
+  const chartId = layer?.crossfilter()?.chartId
   const dimension = layer?.getState()?.encoding?.color?.field
-  const newCf = layer.crossfilter().cloneWithChartId(chartId, layerName)
-  if (dimension) {
+  const newCf = layer?.crossfilter()?.cloneWithChartId(chartId, layerName)
+
+  if (chartId && dimension && newCf) {
     return newCf
       .dimension(dimension)
       .group()

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -109,9 +109,7 @@ async function getTopValues(layer, layerName, size) {
       .dimension(dimension)
       .group()
       .topAsync(size, OFFSET)
-      .then(results => {
-        return results?.map(result => result.key0) ?? null
-      })
+      .then(results => results?.map(result => result.key0) ?? null)
       .catch(error => null)
   } else {
     return null

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -114,9 +114,7 @@ async function getTopValues(layer, size) {
           return null
         }
       })
-      .catch(error => {
-        return null
-      })
+      .catch(error => null)
   } else {
     return Promise.resolve(null)
   }

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -98,8 +98,7 @@ function setColorScaleDomain_v1(domain) {
   }
 }
 
-async function getTopValues(layer) {
-  const NUM_TOP_VALUES = 10
+async function getTopValues(layer, size) {
   const OFFSET = 0
   const dimension = layer?.getState()?.encoding?.color?.field
   if (dimension) {
@@ -107,7 +106,7 @@ async function getTopValues(layer) {
       .crossfilter()
       .dimension(dimension)
       .group()
-      .topAsync(NUM_TOP_VALUES, OFFSET)
+      .topAsync(size, OFFSET)
       .then(results => {
         if (results) {
           return results.map(result => result.key0)
@@ -219,7 +218,10 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
                 domain: layer.colorDomain()
               }
             } else if (color.type === "ordinal") {
-              const colValues = await getTopValues(layer)
+              const colValues = await getTopValues(layer, color.domain.length)
+              console.log("old domain", color.domain)
+              console.log("old range", color.range)
+              console.log("top values (250 limit)", colValues)
               const { newDomain, newRange } = colValues
                 ? getUpdatedDomainRange(
                     colValues,

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -223,6 +223,14 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
                     color.defaultOtherRange
                   )
                 : {}
+
+              // don't show "Other" label if our domain is less than the original domain
+              if (newDomain.length < color.domain.length) {
+                color.hideOther = true
+              } else {
+                color.hideOther = false
+              }
+
               color_legend_descriptor =
                 newDomain && newRange
                   ? { ...color, domain: newDomain, range: newRange }

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -98,19 +98,37 @@ function setColorScaleDomain_v1(domain) {
   }
 }
 
-async function getTopValues(layer, size) {
+async function getTopValues(layer, layerName, size) {
   const OFFSET = 0
+  const chartId = layer.crossfilter().chartId
+  const layerId = layer.getState().currentLayer
   const dimension = layer?.getState()?.encoding?.color?.field
+  // console.log(
+  //   `DIMENSION FOR LAYER ${layer.getState().data[0].table}:`,
+  //   dimension
+  // )
+  const newCf = layer.crossfilter().cloneWithChartId(chartId, layerName)
+  console.log(newCf)
   if (dimension) {
-    return layer
-      .crossfilter()
-      .dimension(dimension)
-      .group()
-      .topAsync(size, OFFSET)
-      .then(results => {
-        return results?.map(result => result.key0) ?? null
-      })
-      .catch(error => null)
+    return (
+      // layer
+      //   .crossfilter()
+      // .getCrossfilter(table, chartId, layerName)
+      newCf
+        .dimension(dimension)
+        .group()
+        .topAsync(size, OFFSET, null, false)
+        .then(results => {
+          // console.log(
+          //   `cf results for layer ${
+          //     layer.getState().data[0].table
+          //   } with dimension ${dimension}:`,
+          //   results
+          // )
+          return results?.map(result => result.key0) ?? null
+        })
+        .catch(error => null)
+    )
   } else {
     return null
   }
@@ -184,6 +202,8 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
           const layerState = layer.getState()
           const color = layer.getState().encoding.color
 
+          // console.log("LAYER STATE:", layerState)
+
           let color_legend_descriptor = null
 
           if (
@@ -210,7 +230,17 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
                 domain: layer.colorDomain()
               }
             } else if (color.type === "ordinal") {
-              const colValues = await getTopValues(layer, color.domain.length)
+              color_legend_descriptor = { ...color }
+              // console.log(color_legend_descriptor)
+              const colValues = await getTopValues(
+                layer,
+                layer_name,
+                color.domain.length
+              )
+              console.log(
+                `COL VALUES FOR ${layerState.data[0].table}:`,
+                colValues
+              )
               const { newDomain, newRange } = colValues
                 ? getUpdatedDomainRange(
                     colValues,
@@ -398,6 +428,10 @@ function legendState_v1(state, useMap) {
   const position = useMap
     ? LEGEND_POSITIONS.BOTTOM_LEFT
     : LEGEND_POSITIONS.TOP_RIGHT
+  if (state?.otherActive) {
+    state.otherActive = false
+  }
+  console.log("LAYER STATE", state)
   if (state.type === "ordinal") {
     return {
       type: "nominal",
@@ -410,16 +444,10 @@ function legendState_v1(state, useMap) {
       // 1. When the Other toggle is enabled, we show color swatch (color defined from color palette in chart editor) for the Other category range,
       // 2. If the Other toggle is disabled, we don't include color swatch for the Other domain
       range:
-        !state.hideOther &&
-        state.hasOwnProperty("showOther") &&
-        state.showOther &&
-        state.otherActive
+        !state.hideOther && state.hasOwnProperty("showOther") && state.showOther
           ? state.range.concat([state.defaultOtherRange]) // When Other is toggled OFF, don't show color swatch in legend
           : state.range,
-      domain:
-        state.hideOther || !state.otherActive
-          ? state.domain
-          : state.domain.concat(["Other"]),
+      domain: state.hideOther ? state.domain : state.domain.concat(["Other"]),
       position
     }
   } else if (

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -161,7 +161,6 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
       getRealLayers(chart.getLayerNames()).map(async layer_name => {
         const layer = chart.getLayer(layer_name)
         if (typeof layer.getPrimaryColorScaleAndLegend === "function") {
-          // ... existing logic for primary color scale and legend
           const vega = chart.getMaterializedVegaSpec()
           const [
             color_scale,
@@ -219,9 +218,6 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
               }
             } else if (color.type === "ordinal") {
               const colValues = await getTopValues(layer, color.domain.length)
-              console.log("old domain", color.domain)
-              console.log("old range", color.range)
-              console.log("top values (250 limit)", colValues)
               const { newDomain, newRange } = colValues
                 ? getUpdatedDomainRange(
                     colValues,
@@ -254,7 +250,6 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
 }
 
 export function handleLegendToggle() {
-  console.log("toggling stacked legend")
   // when chart legend is collapsed, also collapse layer legends
   this.getLayers().forEach(l => {
     if (l.state?.encoding?.color) {
@@ -272,8 +267,6 @@ export function handleLegendToggle() {
 }
 
 export function handleLegendDoneRender() {
-  console.log("stacked legened done rendering")
-
   this.root().classed("horizontal-lasso-tools", () => {
     const legendNode = this.root()
       .select(".legendables")
@@ -398,10 +391,6 @@ function legendState_v1(state, useMap) {
     ? LEGEND_POSITIONS.BOTTOM_LEFT
     : LEGEND_POSITIONS.TOP_RIGHT
   if (state.type === "ordinal") {
-    console.log("LEGEND STATE  ----  ", state)
-    // NOTE(C):
-    // maybe if i call topAsync function here i can get back an updated domain from the cf query?
-    // TODO[C]: domain below is also incorrect
     return {
       type: "nominal",
       title: hasLegendTitleProp(state) ? state.legend.title : "Legend",
@@ -505,8 +494,6 @@ function legendState_v2(state, useMap) {
         extra_range.push(state.default)
       }
     }
-    console.log(state.domain, extra_domain)
-    console.log(state.range, extra_range)
     return {
       type: "nominal",
       title,

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -142,7 +142,6 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
   // Thus, we need to remove extra legends here
   const legends = chart.root().selectAll(".legend")
   const layers = chart.getLayerNames()
-  const _dimOrGroup = chart.group()
 
   if (
     legends.size() > layers.length &&

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -129,24 +129,18 @@ function getUpdatedDomainRangeMapping(
   range,
   defaultColor
 ) {
-  const oldDomainRangeMap = new Map(
+  const oldDomainRange = new Map(
     [...oldDomain].map((key, index) => [key, range[index]])
   )
-  console.log("oldDomainRangeMap:", oldDomainRangeMap)
-  // if the newDomain has a color entry in oldDomain, grab that color and assign for the new map
-  const newDomainRangeMap = new Map(
-    [...newDomain].map((key, index) => [key, oldDomainRangeMap.get(key)])
+  const newDomainRange = new Map(
+    [...newDomain].map((key, index) => [
+      key,
+      oldDomainRange.get(key) ?? defaultColor
+    ])
   )
-  console.log("newDomainRangeMap 1", newDomainRangeMap)
-  newDomainRangeMap.forEach((val, key) => {
-    if (!val) {
-      newDomainRangeMap.set(key, defaultColor)
-    }
-  })
-  console.log("newDomainRangeMap 2", newDomainRangeMap)
   return {
-    newDomain: [...newDomainRangeMap.keys()],
-    newRange: [...newDomainRangeMap.values()]
+    newDomain: [...newDomainRange.keys()],
+    newRange: [...newDomainRange.values()]
   }
 }
 
@@ -235,15 +229,12 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
               }
             } else if (color.type === "ordinal") {
               const colValues = await getTopValues(layer)
-              console.log("orig domain:", color.domain)
-              console.log("orig range:", color.range)
               const { newDomain, newRange } = getUpdatedDomainRangeMapping(
                 colValues,
                 color.domain,
                 color.range,
                 color.defaultOtherRange
               )
-              console.log("color, newD and newR:", color, newDomain, newRange)
               color_legend_descriptor = newDomain
                 ? { ...color, domain: newDomain, range: newRange }
                 : { ...color }

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -224,7 +224,7 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
                     color.range,
                     color.defaultOtherRange
                   )
-                : undefined
+                : {}
               color_legend_descriptor =
                 newDomain && newRange
                   ? { ...color, domain: newDomain, range: newRange }

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -133,10 +133,7 @@ function getUpdatedDomainRangeMapping(
     [...oldDomain].map((key, index) => [key, range[index]])
   )
   const newDomainRange = new Map(
-    [...newDomain].map((key, index) => [
-      key,
-      oldDomainRange.get(key) ?? defaultColor
-    ])
+    [...newDomain].map(key => [key, oldDomainRange.get(key) ?? defaultColor])
   )
   return {
     newDomain: [...newDomainRange.keys()],

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -210,7 +210,6 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
                 domain: layer.colorDomain()
               }
             } else if (color.type === "ordinal") {
-              color_legend_descriptor = { ...color }
               const colValues = await getTopValues(
                 layer,
                 layer_name,

--- a/src/charts/heavyai-table.js
+++ b/src/charts/heavyai-table.js
@@ -206,8 +206,6 @@ export default function heavyaiTable(parent, chartGroup) {
     }
 
     if (sortFuncName === "topAsync") {
-      // NOTE(C): this is where the magic is happening - calls topAsync, a function on the dimOrGroup obj
-      // which hits ImmerseCrossFilterGroup and then calls the query I want in ConnectorWithQueue
       return _dimOrGroup[sortFuncName](size, offset)
         .then(result => callback(null, result))
         .catch(error => callback(error))

--- a/src/charts/heavyai-table.js
+++ b/src/charts/heavyai-table.js
@@ -206,6 +206,8 @@ export default function heavyaiTable(parent, chartGroup) {
     }
 
     if (sortFuncName === "topAsync") {
+      // NOTE(C): this is where the magic is happening - calls topAsync, a function on the dimOrGroup obj
+      // which hits ImmerseCrossFilterGroup and then calls the query I want in ConnectorWithQueue
       return _dimOrGroup[sortFuncName](size, offset)
         .then(result => callback(null, result))
         .catch(error => callback(error))

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -807,33 +807,34 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
       }
     }
 
-    const state = getLegendStateFromChart(_chart, useMap, selectedLayer)
-    _legend.setState(state)
+    getLegendStateFromChart(_chart, useMap, selectedLayer).then(state => {
+      _legend.setState(state)
 
-    if (_chart.isLoaded()) {
-      if (Object.keys(data).length) {
-        _chart._setOverlay({
-          data: data.image,
-          bounds: _renderBoundsMap[data.nonce],
-          nonce: data.nonce,
-          browser,
-          redraw: Boolean(redraw)
-        })
-        _hasBeenRendered = true
+      if (_chart.isLoaded()) {
+        if (Object.keys(data).length) {
+          _chart._setOverlay({
+            data: data.image,
+            bounds: _renderBoundsMap[data.nonce],
+            nonce: data.nonce,
+            browser,
+            redraw: Boolean(redraw)
+          })
+          _hasBeenRendered = true
+        } else {
+          _chart._setOverlay({
+            data: null,
+            bounds: null,
+            nonce: null,
+            browser,
+            redraw: Boolean(redraw)
+          })
+        }
       } else {
-        _chart._setOverlay({
-          data: null,
-          bounds: null,
-          nonce: null,
-          browser,
-          redraw: Boolean(redraw)
+        _chart.map().once("style.load", () => {
+          _chart._doRender(data, redraw, doNotForceData)
         })
       }
-    } else {
-      _chart.map().once("style.load", () => {
-        _chart._doRender(data, redraw, doNotForceData)
-      })
-    }
+    })
   }
 
   _chart._doRedraw = function(data) {


### PR DESCRIPTION
### :speech_balloon: Description

This adds dynamic filtering to the legend for charts using a categorical legend.  Previously the original domain and range were being passed around in this part of the code, and no attempt at retrieving an updated domain was done for legends with categorical data.  Thus the legend displayed the initial domain, regardless if bbox/crossfilters/chart filters/etc were applied.  Now, when we detect categorical data, we make a call to crossfilter for the categorical field, get the updated topN values, pull the original range value (color) applied to each of the new topN values, and provide the legend with an updated domain and range.  This fixed the issue for pointmap, but did not for choropleth, due to a crossfilter bug (feature?).  That is fixed in this accompanying immerse PR: https://github.com/heavyai/immerse/pull/9240

### :page_facing_up: Jira Issue

Closes [FE-17705](https://heavyai.atlassian.net/browse/FE-17705)

### :mag: Verification Steps

1. Create a pointmap with a categorical column as the color measure
2. Zoom around the map, and make sure the legend updates with the values per the current bbox
3. Apply crossfilter, chart filters, dashboard filters, etc, making sure that the legend updates per the applied filters

### :camera_flash: Screenshot
Dynamic legend updating with standard range (no extra colors assigned by user):

https://github.com/heavyai/heavyai-charting/assets/15268289/a7fabf4f-632f-436a-9088-c9a7b07f6aa8

Now with custom range (extra color assignments added by user):

https://github.com/heavyai/heavyai-charting/assets/15268289/a526ba4c-47ae-4356-81ed-12cb531a4417


[FE-17705]: https://heavyai.atlassian.net/browse/FE-17705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ