### PR TITLE
[FE-17481] Preven table sorting option from being hidden

### DIFF
--- a/dist/charting.css
+++ b/dist/charting.css
@@ -801,8 +801,6 @@ body {
     .dc-chart .table-header-item .left-align-btn, .dc-chart .table-header-item .center-align-btn, .dc-chart .table-header-item .right-align-btn {
       min-width: 18px;
       min-height: 24px;
-      right: 0;
-      top: 1px;
       padding: 4px 0px;
       cursor: pointer;
       visibility: hidden;

--- a/dist/charting.css
+++ b/dist/charting.css
@@ -790,22 +790,28 @@ body {
     position: relative; }
   .dc-chart .table-header-item {
     position: relative;
-    white-space: nowrap; }
+    white-space: nowrap;
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    border-bottom: 1px solid #e2e2e2; }
+    .dc-chart .table-header-item .align-btn-container {
+      display: flex;
+      align-items: center; }
     .dc-chart .table-header-item .left-align-btn, .dc-chart .table-header-item .center-align-btn, .dc-chart .table-header-item .right-align-btn {
-      width: 18px;
-      height: 24px;
-      position: absolute;
+      min-width: 18px;
+      min-height: 24px;
       right: 0;
       top: 1px;
       padding: 4px 0px;
       cursor: pointer;
-      display: none; }
+      visibility: hidden; }
       .dc-chart .table-header-item .left-align-btn.active .svg-icon, .dc-chart .table-header-item .center-align-btn.active .svg-icon, .dc-chart .table-header-item .right-align-btn.active .svg-icon {
         fill: #22A7F0; }
       .dc-chart .table-header-item .left-align-btn:hover .svg-icon, .dc-chart .table-header-item .center-align-btn:hover .svg-icon, .dc-chart .table-header-item .right-align-btn:hover .svg-icon {
         fill: #22A7F0; }
     .dc-chart .table-header-item:hover .left-align-btn, .dc-chart .table-header-item:hover .center-align-btn, .dc-chart .table-header-item:hover .right-align-btn {
-      display: block; }
+      visibility: visible; }
     .dc-chart .table-header-item.isFiltered .unfilter-btn {
       display: block; }
     .dc-chart .table-header-item .unfilter-btn {
@@ -824,13 +830,13 @@ body {
   .dc-chart .null-value {
     font-style: italic; }
   .dc-chart .table-sort {
-    border-bottom: 1px solid #e2e2e2;
     color: #868686;
     font-size: 13px;
-    padding: 4px 24px 4px 20px;
+    padding: 4px 4px 4px 20px;
     background: white;
     position: relative;
-    cursor: text; }
+    cursor: text;
+    margin-right: auto; }
     .dc-chart .table-sort.active {
       color: #22A7F0; }
       .dc-chart .table-sort.active:after {

--- a/dist/charting.css
+++ b/dist/charting.css
@@ -784,7 +784,8 @@ body {
     left: 0;
     width: 100%;
     padding: 0 12px;
-    overflow: hidden; }
+    overflow: hidden;
+    border-bottom: 1px solid #e2e2e2; }
   .dc-chart .docked-table-header {
     display: flex;
     position: relative; }
@@ -793,8 +794,7 @@ body {
     white-space: nowrap;
     display: flex;
     align-items: center;
-    flex-direction: row;
-    border-bottom: 1px solid #e2e2e2; }
+    flex-direction: row; }
     .dc-chart .table-header-item .align-btn-container {
       display: flex;
       align-items: center; }
@@ -805,7 +805,8 @@ body {
       top: 1px;
       padding: 4px 0px;
       cursor: pointer;
-      visibility: hidden; }
+      visibility: hidden;
+      display: flex; }
       .dc-chart .table-header-item .left-align-btn.active .svg-icon, .dc-chart .table-header-item .center-align-btn.active .svg-icon, .dc-chart .table-header-item .right-align-btn.active .svg-icon {
         fill: #22A7F0; }
       .dc-chart .table-header-item .left-align-btn:hover .svg-icon, .dc-chart .table-header-item .center-align-btn:hover .svg-icon, .dc-chart .table-header-item .right-align-btn:hover .svg-icon {

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -676,16 +676,23 @@ body {
     .table-header-item {
         position: relative;
         white-space: nowrap;
+        display: flex;
+        align-items: center;
+        flex-direction: row;
+        border-bottom: 1px solid $gray2;
 
+        .align-btn-container {
+          display: flex;
+          align-items: center;
+        }
         .left-align-btn, .center-align-btn, .right-align-btn {
-            width: 18px;
-            height: 24px;
-            position: absolute;
+            min-width: 18px;
+            min-height: 24px;
             right: 0;
             top: 1px;
             padding: 4px 0px;
             cursor: pointer;
-            display: none;
+            visibility: hidden;
 
             &.active {
                 .svg-icon {
@@ -702,7 +709,7 @@ body {
 
         &:hover {
             .left-align-btn, .center-align-btn, .right-align-btn {
-                display: block;
+                visibility: visible;
             }
         }
 
@@ -741,13 +748,13 @@ body {
     }
 
     .table-sort {
-        border-bottom: 1px solid $gray2;
         color: $gray5;
         font-size: 13px;
-        padding: 4px 24px 4px 20px;
+        padding: 4px 4px 4px 20px;
         background: white;
         position: relative;
         cursor: text;
+        margin-right: auto;
 
         &.active {
             color: $blue-main;

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -688,8 +688,6 @@ body {
         .left-align-btn, .center-align-btn, .right-align-btn {
             min-width: 18px;
             min-height: 24px;
-            right: 0;
-            top: 1px;
             padding: 4px 0px;
             cursor: pointer;
             visibility: hidden;

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -666,6 +666,7 @@ body {
         width: 100%;
         padding: 0 12px;
         overflow: hidden;
+        border-bottom: 1px solid $gray2;
     }
 
     .docked-table-header {
@@ -679,7 +680,6 @@ body {
         display: flex;
         align-items: center;
         flex-direction: row;
-        border-bottom: 1px solid $gray2;
 
         .align-btn-container {
           display: flex;
@@ -693,6 +693,7 @@ body {
             padding: 4px 0px;
             cursor: pointer;
             visibility: hidden;
+            display: flex;
 
             &.active {
                 .svg-icon {

--- a/src/charts/heavyai-table.js
+++ b/src/charts/heavyai-table.js
@@ -505,6 +505,13 @@ export default function heavyaiTable(parent, chartGroup) {
         .append("div")
         .attr("class", "table-header-item")
         .classed("isFiltered", () => d.expression in _filteredColumns)
+        .style(
+          "width",
+          d3
+            .select(this)
+            .node()
+            .getBoundingClientRect().width + "px"
+        )
 
       const sortLabel = headerItem
         .append("div")
@@ -517,15 +524,6 @@ export default function heavyaiTable(parent, chartGroup) {
         })
         .classed("active", _sortColumn ? _sortColumn.index === i : false)
         .classed(_sortColumn ? _sortColumn.order : "", true)
-        .style(
-          "width",
-          d3
-            .select(this)
-            .node()
-            .getBoundingClientRect().width + "px"
-        )
-
-      const textSpan = sortLabel.append("span").text(d.label)
 
       const sortButton = sortLabel
         .append("div")
@@ -548,6 +546,8 @@ export default function heavyaiTable(parent, chartGroup) {
           _chart.redrawAsync()
         })
 
+      const textSpan = sortLabel.append("span").text(d.label)
+
       sortButton
         .append("svg")
         .attr("class", "svg-icon")
@@ -564,8 +564,12 @@ export default function heavyaiTable(parent, chartGroup) {
         .append("use")
         .attr("xlink:href", "#icon-arrow1")
 
+      const alignBtnContainer = headerItem
+        .append("div")
+        .attr("class", "align-btn-container")
+
       // left align button
-      headerItem
+      alignBtnContainer
         .append("div")
         .attr("class", "left-align-btn")
         .classed("active", () => _chart.isColLeftAligned(i))
@@ -588,7 +592,7 @@ export default function heavyaiTable(parent, chartGroup) {
         .attr("xlink:href", "#icon-caret-left")
 
       // center align button
-      headerItem
+      alignBtnContainer
         .append("div")
         .attr("class", "center-align-btn")
         .classed("active", () => _chart.isColCenterAligned(i))
@@ -611,7 +615,7 @@ export default function heavyaiTable(parent, chartGroup) {
         .attr("xlink:href", "#icon-align-center")
 
       // right align button
-      headerItem
+      alignBtnContainer
         .append("div")
         .attr("class", "right-align-btn")
         .classed("active", () => _chart.isColRightAligned(i))


### PR DESCRIPTION
### :speech_balloon: Description

Fixes issue where if table chart was resized to a small size, the column alignment buttons would float over the column name and sort button.  Now the alignment buttons will move as close as they can to the column title before getting cut off.  Moved these buttons to their own wrapper, with a flexbox layout and less padding so the buttons can get closer to the column title before being cut off.

### :page_facing_up: Jira Issue

Closes [FE-17481](https://heavyai.atlassian.net/browse/FE-17481)

### :mag: Verification Steps

1. Follow repro steps in corresponding jira ticket
2. Ensure the alignment buttons no longer overlay over the sort button and you can still sort a column when the table is resized to be very small.

### :camera_flash: Screenshot

https://github.com/heavyai/heavyai-charting/assets/15268289/c68b0b1a-dd83-4507-a45d-a056fb8cebee



[FE-17481]: https://heavyai.atlassian.net/browse/FE-17481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ