### PR TITLE
Add hash coloring functions for d3 charts; call when value is string

### DIFF
--- a/src/mixins/color-mixin.js
+++ b/src/mixins/color-mixin.js
@@ -213,11 +213,9 @@ export default function colorMixin(_chart) {
     if (typeof measureColor === "string") {
       const hash = cyrb53(measureColor)
       const colorIndex = hash % colors.length
-      console.log(colors[colorIndex])
       return colors[colorIndex]
     }
     const colorIndex = measureColor % colors.length
-    console.log(colors[colorIndex])
     return colors[colorIndex]
   }
 

--- a/src/mixins/color-mixin.js
+++ b/src/mixins/color-mixin.js
@@ -166,7 +166,11 @@ export default function colorMixin(_chart) {
     const range = _chart.colors().range()
     const middleColor = range[Math.floor(range.length / 2)]
 
-    return _colors(_colorAccessor.call(this, data, index)) || middleColor
+    const value = _colorAccessor.call(this, data, index)
+
+    return typeof value === "string"
+      ? _chart.determineColorByValue(value, range)
+      : _colors(_colorAccessor.call(this, data, index)) || middleColor
   }
 
   /**
@@ -183,6 +187,38 @@ export default function colorMixin(_chart) {
     }
     _chart.getColor = colorCalculator
     return _chart
+  }
+
+  const cyrb53 = (str, seed = 0) => {
+    let h1 = 0xdeadbeef ^ seed
+    let h2 = 0x41c6ce57 ^ seed
+    for (let i = 0, ch; i < str.length; i++) {
+      ch = str.charCodeAt(i)
+      h1 = Math.imul(h1 ^ ch, 2654435761)
+      h2 = Math.imul(h2 ^ ch, 1597334677)
+    }
+
+    h1 =
+      Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^
+      Math.imul(h2 ^ (h2 >>> 13), 3266489909)
+
+    h2 =
+      Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^
+      Math.imul(h1 ^ (h1 >>> 13), 3266489909)
+
+    return 4294967296 * (2097151 & h2) + (h1 >>> 0)
+  }
+
+  _chart.determineColorByValue = (measureColor, colors) => {
+    if (typeof measureColor === "string") {
+      const hash = cyrb53(measureColor)
+      const colorIndex = hash % colors.length
+      console.log(colors[colorIndex])
+      return colors[colorIndex]
+    }
+    const colorIndex = measureColor % colors.length
+    console.log(colors[colorIndex])
+    return colors[colorIndex]
   }
 
   return _chart


### PR DESCRIPTION
- Add hash function into charting
- When assigning colors to string values, use hash function instead of d3 coloring