### PR TITLE
[FE-16381] _layer.lastFilteredSize is not a function 

### DIFF
--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -283,7 +283,7 @@ export default function rasterLayerLineMixin(_layer) {
         // Contour doesn't seem to go through any of the charting sampling logic, so using the group size should be fine, ostensibly
         isContourType(state)
           ? lastFilteredSize(_layer.crossfilter().getId())
-          : _layer.lastFilteredSize()
+          : _layer.getLastFilteredSize()
       )
       .filter(
         transform =>


### PR DESCRIPTION
Corrects function name; `lastFilteredSize` does not exist