### PR TITLE
[FE-18033] Don't pass in stale domain to maybeUpdateAllOthers

### DIFF
--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -481,8 +481,20 @@ export default function pieChart(parent, chartGroup) {
       const newRange = pieData.map((d, i) => _chart.getColor(d.data, i))
       _chart.customRange(newRange)
     } else if (domain.length > 0) {
-      maybeUpdateDomainRange(_chart, pieData, d => d.data.key0, domain, range)
-      maybeUpdateAllOthers(_chart, pieData, domain, range)
+      maybeUpdateDomainRange(
+        _chart,
+        pieData,
+        d => d.data.key0,
+        domain,
+        range,
+        true
+      )
+      maybeUpdateAllOthers(
+        _chart,
+        pieData,
+        _chart.customDomain(),
+        _chart.customRange()
+      )
     }
 
     updateSlicePaths(pieData, arc)


### PR DESCRIPTION
Addresses issues with d3 domain setting - previously, when we have a palette mapping, by sending in `domain` and `range` to `maybeUpdateAllOthers`, we were sending in the mapping's domain/range - which, if created by a different chart, could be much larger than what the pie chart is displaying, leading to discrepancies between `CustomColorsList` and what was actually shown on the chart.  Since `maybeUpdateDomainRange` updates `_chart.customDomain/Range()`, pass that into the next function instead so we are using the updated domain for pie.

Bubble chart did not suffer from this bug as it doesn't have all others, so was never making that second function call that messed up the domain/range.
