### PR TITLE
[FE-18003] Bug fix - modifying mapping and cancelling removed mapping

### DIFF
--- a/src/charts/bubble-chart.js
+++ b/src/charts/bubble-chart.js
@@ -466,8 +466,8 @@ export default function bubbleChart(parent, chartGroup) {
       data.sort((a, b) => d3.descending(radiusAccessor(a), radiusAccessor(b)))
     }
 
-    const domain = _chart.customDomain()
-    const range = _chart.customRange()
+    const domain = _chart.customDomain() ?? []
+    const range = _chart.customRange() ?? []
 
     if (domain.length === 0 && range.length === 0) {
       const newDomain = data.map(d => d.key0)

--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -463,8 +463,8 @@ export default function pieChart(parent, chartGroup) {
   }
 
   function updateElements(pieData, arc) {
-    const domain = _chart.customDomain()
-    const range = _chart.customRange()
+    const domain = _chart.customDomain() ?? []
+    const range = _chart.customRange() ?? []
 
     // if custom domain is empty, generate it from the pieData
     if (domain.length === 0 && range.length === 0) {

--- a/src/mixins/color-mixin.js
+++ b/src/mixins/color-mixin.js
@@ -176,7 +176,7 @@ export default function colorMixin(_chart) {
         : _colors(_colorAccessor.call(this, data, index)) || middleColor
 
     let customColor = null
-    if (_chart.customRange().length > 0) {
+    if (_chart.customRange()?.length > 0) {
       const customDomain = _chart.customDomain()
       const customRange = _chart.customRange()
       if (Array.isArray(value)) {


### PR DESCRIPTION
Issue was a fail to safeguard against `customRange` being undefined, which threw an error, but then also was triggering a `setCustomDefaultOtherColorValue` call in immerse, which wiped out the `paletteMappingId` on `chart.color` for D3 charts, causing the mapping not to be selected when returning to the chart.