### PR TITLE
[FE-18172] Esc key binding to close ruler

### DIFF
--- a/src/mixins/map-mixin.js
+++ b/src/mixins/map-mixin.js
@@ -738,15 +738,21 @@ export default function mapMixin(
     _map.dragRotate.disable()
     _map.touchZoomRotate.disableRotation()
 
-    _map.addControl(
-      new RulerControl({
-        linePaint: {
-          "line-color": "#999",
-          "line-width": 2
+    const rulerControl = new RulerControl({
+      linePaint: {
+        "line-color": "#999",
+        "line-width": 2
+      }
+    })
+    _map.addControl(rulerControl, "bottom-right")
+
+    _chart.root().on("keydown", () => {
+      if (d3.event.key === "Escape" || d3.event.key === 27) {
+        if (rulerControl?.isActive) {
+          rulerControl.deactivate()
         }
-      }),
-      "bottom-right"
-    )
+      }
+    })
     _map.addControl(new _mapboxgl.NavigationControl(), "bottom-right")
     _map.addControl(new _mapboxgl.AttributionControl(), _attribLocation)
     _map.addControl(


### PR DESCRIPTION
This adds an event listener so the Escape key will close the ruler if it's active

1. Create any raster chart
2. Click ruler and click map to create some measurements
3. Hit escape key
4. Ruler should de-activate and measurements go away


# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
