### PR TITLE
[FE-18169] In fullColorHashing mode, add infinite scroll to legend

### DIFF
--- a/dist/charting.css
+++ b/dist/charting.css
@@ -2021,6 +2021,9 @@ body {
   overflow-y: auto;
   padding: 0 4px 4px 4px; }
 
+.nominal-legend:not(.legendables) .body {
+  max-height: 300px; }
+
 .nominal-legend .legend-row {
   display: flex;
   align-items: center;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10486,8 +10486,8 @@
       "dev": true
     },
     "legendables": {
-      "version": "git+https://github.com/heavyai/legendables.git#292fded68a222ffa5cefa3d2f59779026a23f022",
-      "from": "git+https://github.com/heavyai/legendables.git#292fded68a222ffa5cefa3d2f59779026a23f022",
+      "version": "git+https://github.com/heavyai/legendables.git#d3d3fc5f6dc5aae191b123256162f063edc5c9c1",
+      "from": "git+https://github.com/heavyai/legendables.git#d3d3fc5f6dc5aae191b123256162f063edc5c9c1",
       "requires": {
         "@types/node": "^11.13.0",
         "d3-dispatch": "^1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10486,8 +10486,8 @@
       "dev": true
     },
     "legendables": {
-      "version": "git+https://github.com/heavyai/legendables.git#7f373800a813bd4dc6fe13269155abf14326a649",
-      "from": "git+https://github.com/heavyai/legendables.git#7f373800a813bd4dc6fe13269155abf14326a649",
+      "version": "git+https://github.com/heavyai/legendables.git#9c14510163715ccb028716750a39ca21c09443d8",
+      "from": "git+https://github.com/heavyai/legendables.git#9c14510163715ccb028716750a39ca21c09443d8",
       "requires": {
         "@types/node": "^11.13.0",
         "d3-dispatch": "^1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10486,8 +10486,8 @@
       "dev": true
     },
     "legendables": {
-      "version": "git+https://github.com/heavyai/legendables.git#d3d3fc5f6dc5aae191b123256162f063edc5c9c1",
-      "from": "git+https://github.com/heavyai/legendables.git#d3d3fc5f6dc5aae191b123256162f063edc5c9c1",
+      "version": "git+https://github.com/heavyai/legendables.git#7f373800a813bd4dc6fe13269155abf14326a649",
+      "from": "git+https://github.com/heavyai/legendables.git#7f373800a813bd4dc6fe13269155abf14326a649",
       "requires": {
         "@types/node": "^11.13.0",
         "d3-dispatch": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "chevrotain": "~6.5.0",
     "d3": "^3.5.17",
     "fast-deep-equal": "^2.0.1",
-    "legendables": "git+https://github.com/heavyai/legendables.git#d3d3fc5f6dc5aae191b123256162f063edc5c9c1",
+    "legendables": "git+https://github.com/heavyai/legendables.git#7f373800a813bd4dc6fe13269155abf14326a649",
     "mapbox-gl": "1.9.1",
     "moment": "^2.29.4",
     "ramda": "0.21.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "chevrotain": "~6.5.0",
     "d3": "^3.5.17",
     "fast-deep-equal": "^2.0.1",
-    "legendables": "git+https://github.com/heavyai/legendables.git#292fded68a222ffa5cefa3d2f59779026a23f022",
+    "legendables": "git+https://github.com/heavyai/legendables.git#d3d3fc5f6dc5aae191b123256162f063edc5c9c1",
     "mapbox-gl": "1.9.1",
     "moment": "^2.29.4",
     "ramda": "0.21.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "chevrotain": "~6.5.0",
     "d3": "^3.5.17",
     "fast-deep-equal": "^2.0.1",
-    "legendables": "git+https://github.com/heavyai/legendables.git#7f373800a813bd4dc6fe13269155abf14326a649",
+    "legendables": "git+https://github.com/heavyai/legendables.git#9c14510163715ccb028716750a39ca21c09443d8",
     "mapbox-gl": "1.9.1",
     "moment": "^2.29.4",
     "ramda": "0.21.0",

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -307,9 +307,9 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
                     color.originalDomain,
                     color.originalRange,
                     color.defaultOtherRange,
-                    color?.fullColorHashing,
+                    color.fullColorHashing,
                     color.palette.val,
-                    color?.customColors
+                    color.customColors
                   )
                 : {}
 

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -506,9 +506,11 @@ export async function handleLegendFetchDomain(index, page) {
     return
   }
 
+  // controls pagination - aka what the OFFSET in the query will be
   const currentIndex = legendIndex
     ? legendIndex + LEGEND_CATEGORY_SIZE
     : originalDomain.length
+  // grab next "page" of values from database
   let colValues = await getTopValues(
     layer,
     layerName,

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -293,22 +293,11 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
                 domain: layer.colorDomain()
               }
             } else if (color.type === "ordinal") {
-              let colValues
-              // if (color.fullColorHashing) {
-              // start with page 0, modify offset to function
-              //   colValues = await getTopValues(
-              //     layer,
-              //     layer_name,
-              //     100,
-              //     color.legendPage ? color.legendPage * 100 : 0
-              //   )
-              // } else {
-              colValues = await getTopValues(
+              const colValues = await getTopValues(
                 layer,
                 layer_name,
                 color.originalDomain.length
               )
-              // }
 
               if (color.sorted) {
                 colValues = sortDomain(color.sorted, colValues)
@@ -325,25 +314,6 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
                     color?.customColors
                   )
                 : {}
-              // let newDomain
-              // let newRange
-              // if (color.fullColorHashing) {
-              //   ;({ newDomain, newRange } = buildFullHashedDomainRange(
-              //     color.originalDomain,
-              //     color.originalRange,
-              //     colValues,
-              //     color.palette.val
-              //   ))
-              // } else {
-              //   ;({ newDomain, newRange } = colValues
-              //     ? getUpdatedDomainRange(
-              //         colValues,
-              //         color.originalDomain,
-              //         color.originalRange,
-              //         color.defaultOtherRange
-              //       )
-              //     : {})
-              // }
 
               // don't show the other category when new domain is smaller than original max
               color.otherActive = false

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -118,7 +118,6 @@ const getTotalValuesCount = async (layer, layerName) => {
       .dimension(dimension)
       .group()
       .all()
-      .then(res => res)
     return allValues.length
   }
 }
@@ -175,9 +174,8 @@ function getUpdatedDomainRange(
     ? new Map(
         [...newDomain].map(key => [
           key,
-          customColorsDomainRange && customColorsDomainRange.get(key)
-            ? customColorsDomainRange.get(key)
-            : determineColorByValue(key, palette)
+          customColorsDomainRange?.get?.(key) ??
+            determineColorByValue(key, palette)
         ])
       )
     : new Map(

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -148,13 +148,44 @@ async function getTopValues(layer, layerName, size, offset = 0) {
   }
 }
 
-function getUpdatedDomainRange(newDomain, oldDomain, range, defaultColor) {
+function getUpdatedDomainRange(
+  newDomain,
+  oldDomain,
+  range,
+  defaultColor,
+  fullColorHashing,
+  palette,
+  customColors
+) {
+  const customColorsDomainRange =
+    fullColorHashing &&
+    customColors?.domain?.length > 0 &&
+    customColors?.range?.length > 0
+      ? new Map(
+          [...customColors.domain].map((key, index) => [
+            key,
+            customColors.range[index]
+          ])
+        )
+      : null
   const oldDomainRange = new Map(
     [...oldDomain].map((key, index) => [key, range[index]])
   )
-  const newDomainRange = new Map(
-    [...newDomain].map(key => [key, oldDomainRange.get(key) ?? defaultColor])
-  )
+  const newDomainRange = fullColorHashing
+    ? new Map(
+        [...newDomain].map(key => [
+          key,
+          customColorsDomainRange
+            ? customColorsDomainRange.get(key)
+            : determineColorByValue(key, palette)
+        ])
+      )
+    : new Map(
+        [...newDomain].map(key => [
+          key,
+          oldDomainRange.get(key) ?? defaultColor
+        ])
+      )
   return {
     newDomain: [...newDomainRange.keys()],
     newRange: [...newDomainRange.values()]
@@ -288,7 +319,10 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
                     colValues,
                     color.originalDomain,
                     color.originalRange,
-                    color.defaultOtherRange
+                    color.defaultOtherRange,
+                    color?.fullColorHashing,
+                    color.palette.val,
+                    color?.customColors
                   )
                 : {}
               // let newDomain

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -175,7 +175,7 @@ function getUpdatedDomainRange(
     ? new Map(
         [...newDomain].map(key => [
           key,
-          customColorsDomainRange
+          customColorsDomainRange && customColorsDomainRange.get(key)
             ? customColorsDomainRange.get(key)
             : determineColorByValue(key, palette)
         ])
@@ -489,6 +489,11 @@ export async function handleLegendFetchDomain(index, page) {
     fullColorHashing,
     legendIndex
   } = color
+
+  if (!fullColorHashing) {
+    return
+  }
+
   const currentDomain = filteredDomain ?? domain
   const currentRange = filteredRange ?? range
   const totalValuesCount = await getTotalValuesCount(layer, layerName)

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -293,7 +293,7 @@ export async function getLegendStateFromChart(chart, useMap, selectedLayer) {
                 domain: layer.colorDomain()
               }
             } else if (color.type === "ordinal") {
-              const colValues = await getTopValues(
+              let colValues = await getTopValues(
                 layer,
                 layer_name,
                 color.originalDomain.length

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -826,9 +826,6 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
     }
 
     getLegendStateFromChart(_chart, useMap, selectedLayer).then(state => {
-      if (!state.pageNumber) {
-        state.pageNumber = 0
-      }
       _legend.setState(state)
 
       if (_chart.isLoaded()) {

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -6,7 +6,8 @@ import {
   handleLegendLock,
   handleLegendOpen,
   handleLegendToggle,
-  handleLegendSort
+  handleLegendSort,
+  handleLegendFetchDomain
 } from "../chart-addons/stacked-legend"
 import coordinateGridRasterMixin from "../mixins/coordinate-grid-raster-mixin"
 import mapMixin from "../mixins/map-mixin"
@@ -825,6 +826,9 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
     }
 
     getLegendStateFromChart(_chart, useMap, selectedLayer).then(state => {
+      if (!state.pageNumber) {
+        state.pageNumber = 0
+      }
       _legend.setState(state)
 
       if (_chart.isLoaded()) {
@@ -1014,6 +1018,8 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
   _legend.on("input", handleLegendInput.bind(_chart))
   _legend.on("toggle", handleLegendToggle.bind(_chart))
   _legend.on("sort", handleLegendSort.bind(_chart))
+  _legend.on("fetchDomain", handleLegendFetchDomain.bind(_chart))
+
   _legend.on("doneRender", handleLegendDoneRender.bind(_chart))
   _legend.on("doneRender", function(state) {
     // Sometimes the legend gets disconnected from the DOM?

--- a/src/mixins/color-mixin.js
+++ b/src/mixins/color-mixin.js
@@ -1,4 +1,5 @@
 import d3 from "d3"
+import { determineColorByValue } from "../utils/color-helpers"
 
 /**
  * The Color Mixin is an abstract chart functional class providing universal coloring support
@@ -174,7 +175,7 @@ export default function colorMixin(_chart) {
 
     const color =
       typeof value === "string" && _chart.getDimensionLength() === 1
-        ? _chart.determineColorByValue(value, range)
+        ? determineColorByValue(value, range)
         : _colors(_colorAccessor.call(this, data, index)) || middleColor
 
     let customColor = null
@@ -242,36 +243,6 @@ export default function colorMixin(_chart) {
     }
     _chart.getColor = colorCalculator
     return _chart
-  }
-
-  const cyrb53 = (str, seed = 0) => {
-    let h1 = 0xdeadbeef ^ seed
-    let h2 = 0x41c6ce57 ^ seed
-    for (let i = 0, ch; i < str.length; i++) {
-      ch = str.charCodeAt(i)
-      h1 = Math.imul(h1 ^ ch, 2654435761)
-      h2 = Math.imul(h2 ^ ch, 1597334677)
-    }
-
-    h1 =
-      Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^
-      Math.imul(h2 ^ (h2 >>> 13), 3266489909)
-
-    h2 =
-      Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^
-      Math.imul(h1 ^ (h1 >>> 13), 3266489909)
-
-    return 4294967296 * (2097151 & h2) + (h1 >>> 0)
-  }
-
-  _chart.determineColorByValue = (measureColor, colors) => {
-    if (typeof measureColor === "string") {
-      const hash = cyrb53(measureColor)
-      const colorIndex = hash % colors.length
-      return colors[colorIndex]
-    }
-    const colorIndex = measureColor % colors.length
-    return colors[colorIndex]
   }
 
   return _chart

--- a/src/utils/color-helpers.js
+++ b/src/utils/color-helpers.js
@@ -38,6 +38,36 @@ export function maybeUpdateAllOthers(chart, data, domain, range) {
   chart.customRange(range)
 }
 
+const cyrb53 = (str, seed = 0) => {
+  let h1 = 0xdeadbeef ^ seed
+  let h2 = 0x41c6ce57 ^ seed
+  for (let i = 0, ch; i < str.length; i++) {
+    ch = str.charCodeAt(i)
+    h1 = Math.imul(h1 ^ ch, 2654435761)
+    h2 = Math.imul(h2 ^ ch, 1597334677)
+  }
+
+  h1 =
+    Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^
+    Math.imul(h2 ^ (h2 >>> 13), 3266489909)
+
+  h2 =
+    Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^
+    Math.imul(h1 ^ (h1 >>> 13), 3266489909)
+
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0)
+}
+
+export const determineColorByValue = (value, colors) => {
+  if (typeof value === "string") {
+    const hash = cyrb53(value)
+    const colorIndex = hash % colors.length
+    return colors[colorIndex]
+  }
+  const colorIndex = value % colors.length
+  return colors[colorIndex]
+}
+
 export function buildHashedColor(field, range, paletteLength, customColors) {
   if (customColors?.domain?.length > 0 && customColors?.range?.length > 0) {
     const domain = customColors.domain


### PR DESCRIPTION

Depends on legendables PR: https://github.com/heavyai/legendables/pull/12

When `fullColorHashing` is enabled, revise the legend so that it has infinite scrolling, so that it will continuously load up more values from crossfilter until it has reached the end of the data.  This also changes the initial rendering of colors on the legend - rather than pulling colors from the initial domain (as defined by immerse), it will instead first look for any customized colors, and hash the rest of them to match with the new `fullColorHashing` querying.

By default loads results in batches of 50.  Legend filtering should still work, and should only load as many columns as are available per the current bounding box.  Also moves hashing function to separate helper function.