### PR TITLE
[HOTFIX] Preinstall script to conditionally run npm-force-resolutions

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@
 # local files
 node_modules
 bower_components
-scripts
 
 # ide files
 *.iml

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lint:fix": "./node_modules/.bin/eslint --fix $(find src -name \"*.js\" ! -name '*.spec.js')",
     "lint:errors": "npm run lint -- --quiet",
     "nyc": "nyc",
-    "preinstall": "npx npm-force-resolutions",
+    "preinstall": "node ./scripts/preinstall-if-root.js",
     "report": "nyc report --reporter=lcov && open coverage/lcov-report/index.html",
     "selenium:install": "selenium-standalone install --version=3.0.0-beta4",
     "selenium:start": "selenium-standalone start --version=3.0.0-beta4",

--- a/scripts/preinstall-if-root.js
+++ b/scripts/preinstall-if-root.js
@@ -1,0 +1,14 @@
+const fs = require("fs")
+const path = require("path")
+
+// Check if current directory has a package-lock.json (i.e., is a root project)
+const lockPath = path.resolve(process.cwd(), "package-lock.json")
+
+if (fs.existsSync(lockPath)) {
+  // We're in the project root, safe to run
+  const { execSync } = require("child_process")
+  console.log("Running npm-force-resolutions...")
+  execSync("npx npm-force-resolutions", { stdio: "inherit" })
+} else {
+  console.log("Skipping npm-force-resolutions (not in project root)")
+}


### PR DESCRIPTION
Create script to only run `npm-force-resolutions` if building as a stand-alone library.  This will prevent it from running that package when building charting in the immerse dep install process, which causes the build to fail.